### PR TITLE
Refresh only online devices

### DIFF
--- a/media_player/alexa.py
+++ b/media_player/alexa.py
@@ -222,7 +222,7 @@ def setup_alexa(hass, config, add_devices_callback, login_obj):
                                          update_devices, url)
                 alexa_clients[device['serialNumber']] = new_client
                 new_alexa_clients.append(new_client)
-            else:
+            elif device['online']:
                 alexa_clients[device['serialNumber']].refresh(device)
 
         if new_alexa_clients:


### PR DESCRIPTION
~~This should address #26~~
Since all devices are autodiscovered, it didn't make sense to create a per device filter in the configuration.  

~~This also enables a new optional configuration option which is by default on to only show online devices.~~
`media_player:
  - platform: alexa
    email: !secret amazon_user
    password: !secret amazon_pass
    url: amazon.com
    onlineonly: True`