### PR TITLE
Handle Amazon verification pages

### DIFF
--- a/media_player/alexa.py
+++ b/media_player/alexa.py
@@ -3,7 +3,7 @@ Support to interface with Alexa Devices.
 
 For more details about this platform, please refer to the documentation at
 https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers-needed/58639
-VERSION 0.9.2
+VERSION 0.9.3
 """
 import logging
 
@@ -36,7 +36,7 @@ SUPPORT_ALEXA = (SUPPORT_PAUSE | SUPPORT_PREVIOUS_TRACK |
                  SUPPORT_PLAY_MEDIA | SUPPORT_TURN_OFF |
                  SUPPORT_VOLUME_MUTE | SUPPORT_PAUSE |
                  SUPPORT_SELECT_SOURCE)
-_CONFIGURING = {}
+_CONFIGURING = []
 _LOGGER = logging.getLogger(__name__)
 
 REQUIREMENTS = ['beautifulsoup4==4.6.0', 'simplejson==3.16.0']
@@ -53,53 +53,79 @@ ALEXA_TTS_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
     vol.Required(ATTR_MESSAGE): cv.string,
 })
 
+CONF_DEBUG = 'debug'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_EMAIL): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_URL): cv.string,
+    vol.Optional(CONF_DEBUG, default=False): cv.boolean,
 })
 
 
 def request_configuration(hass, config, setup_platform_callback,
-                          captcha_url=None):
+                          status=None):
     """Request configuration steps from the user."""
     configurator = hass.components.configurator
-    failed_login = False
 
     async def configuration_callback(callback_data):
         """Handle the submitted configuration."""
-        def done():
-            configurator.request_done(_CONFIGURING['alexa'])
-
-        hass.async_add_job(done)
         hass.async_add_job(setup_platform_callback, callback_data)
 
-    if 'alexa' in _CONFIGURING:
-        failed_login = True
-        configurator.request_done(_CONFIGURING.pop('alexa'))
-
     # Get Captcha
-    if (captcha_url is not None):
-        _CONFIGURING['alexa'] = configurator.request_config(
-            "Alexa Media Player", configuration_callback,
+    if (status and 'captcha_image_url' in status and
+            status['captcha_image_url'] is not None):
+        config_id = configurator.request_config(
+            "Alexa Media Player - Captcha", configuration_callback,
             description=('Please enter the text for the captcha.'
                          ' Please enter anything if the image is missing.'
                          ),
-            description_image=captcha_url,
+            description_image=status['captcha_image_url'],
             submit_caption="Confirm",
             fields=[{'id': 'captcha', 'name': 'Captcha'}]
         )
-        if failed_login:
-            configurator.notify_errors(
-                _CONFIGURING['alexa'], "Failed to login, please try again.")
-    else:  # Get 2FA code
-        _CONFIGURING['alexa'] = configurator.request_config(
-            "Alexa Media Player", configuration_callback,
+    elif (status and 'securitycode_required' in status and
+            status['securitycode_required']):  # Get 2FA code
+        config_id = configurator.request_config(
+            "Alexa Media Player - 2FA", configuration_callback,
             description=('Please enter your Two-Factor Security code.'),
             submit_caption="Confirm",
             fields=[{'id': 'securitycode', 'name': 'Security Code'}]
         )
+    elif (status and 'claimspicker_required' in status and
+            status['claimspicker_required']):  # Get picker method
+        options = status['claimspicker_message']
+        config_id = configurator.request_config(
+            "Alexa Media Player - Verification Method", configuration_callback,
+            description=('Please select the verification method. '
+                         '(e.g., sms or email).<br />{}').format(
+                         options
+                         ),
+            submit_caption="Confirm",
+            fields=[{'id': 'claimsoption', 'name': 'Option'}]
+        )
+    elif (status and 'verificationcode_required' in status and
+            status['verificationcode_required']):  # Get picker method
+        config_id = configurator.request_config(
+            "Alexa Media Player - Verification Code", configuration_callback,
+            description=('Please enter received verification code.'),
+            submit_caption="Confirm",
+            fields=[{'id': 'verificationcode', 'name': 'Verification Code'}]
+        )
+    else:  # Check login
+        config_id = configurator.request_config(
+            "Alexa Media Player - Begin", configuration_callback,
+            description=('Please hit confirm to begin login attempt.'),
+            submit_caption="Confirm",
+            fields=[]
+        )
+    _CONFIGURING.append(config_id)
+    if (len(_CONFIGURING) > 0 and 'error_message' in status
+            and status['error_message']):
+        configurator.notify_errors(  # use sync to delay next pop
+            _CONFIGURING[len(_CONFIGURING)-1], status['error_message'])
+    if (len(_CONFIGURING) > 1):
+        configurator.async_request_done(_CONFIGURING.pop(0))
 
 
 def setup_platform(hass, config, add_devices_callback,
@@ -112,52 +138,54 @@ def setup_platform(hass, config, add_devices_callback,
     password = config.get(CONF_PASSWORD)
     url = config.get(CONF_URL)
 
-    login = AlexaLogin(url, email, password, hass)
+    login = AlexaLogin(url, email, password, hass.config.path,
+                       config.get(CONF_DEBUG))
 
     async def setup_platform_callback(callback_data):
-        _LOGGER.debug("Status: {} got captcha: {} securitycode: {}".format(
+        _LOGGER.debug(("Status: {} got captcha: {} securitycode: {}"
+                      " Claimsoption: {} VerificationCode: {}").format(
             login.status,
             callback_data.get('captcha'),
-            callback_data.get('securitycode')))
+            callback_data.get('securitycode'),
+            callback_data.get('claimsoption'),
+            callback_data.get('verificationcode')))
         login.login(captcha=callback_data.get('captcha'),
-                    securitycode=callback_data.get('securitycode'))
-        if ('login_successful' in login.status and
-                login.status['login_successful']):
-            _LOGGER.debug("Captcha/2FA successful; setting up Alexa devices")
-            hass.async_add_job(setup_alexa, hass, config,
-                               add_devices_callback, login)
-            global _CONFIGURING
-            _CONFIGURING = {}
-        elif ('securitycode_required' in login.status and
-              login.status['securitycode_required']):
-            _LOGGER.debug("2FA required; creating configurator")
-            hass.async_add_job(request_configuration, hass, config,
-                               setup_platform_callback,
-                               None)
+                    securitycode=callback_data.get('securitycode'),
+                    claimsoption=callback_data.get('claimsoption'),
+                    verificationcode=callback_data.get('verificationcode'))
+        testLoginStatus(hass, config, add_devices_callback, login,
+                        setup_platform_callback)
 
-        else:
-            _LOGGER.debug("Captcha/2FA failed; requesting new captcha")
-            login.reset_login()
-            login.login()
-            hass.async_add_job(request_configuration, hass, config,
-                               setup_platform_callback,
-                               login.status['captcha_image_url'])
+    testLoginStatus(hass, config, add_devices_callback, login,
+                    setup_platform_callback)
 
+
+def testLoginStatus(hass, config, add_devices_callback, login,
+                    setup_platform_callback):
+    """Test the login status."""
     if 'login_successful' in login.status and login.status['login_successful']:
         _LOGGER.debug("Setting up Alexa devices")
         hass.async_add_job(setup_alexa, hass, config,
                            add_devices_callback, login)
+        return
     elif ('captcha_required' in login.status and
           login.status['captcha_required']):
         _LOGGER.debug("Creating configurator to request captcha")
-        hass.async_add_job(request_configuration, hass, config,
-                           setup_platform_callback,
-                           login.status['captcha_image_url'])
     elif ('securitycode_required' in login.status and
             login.status['securitycode_required']):
-        hass.async_add_job(request_configuration, hass, config,
-                           setup_platform_callback,
-                           None)
+        _LOGGER.debug("Creating configurator to request 2FA")
+    elif ('claimspicker_required' in login.status and
+            login.status['claimspicker_required']):
+        _LOGGER.debug("Creating configurator to select verification option")
+    elif ('verificationcode_required' in login.status and
+            login.status['verificationcode_required']):
+        _LOGGER.debug("Creating configurator to enter verification code")
+    elif ('login_failed' in login.status and
+            login.status['login_failed']):
+        _LOGGER.debug("Creating configurator to start new login attempt")
+    hass.async_add_job(request_configuration, hass, config,
+                       setup_platform_callback,
+                       login.status)
 
 
 def setup_alexa(hass, config, add_devices_callback, login_obj):
@@ -173,6 +201,11 @@ def setup_alexa(hass, config, add_devices_callback, login_obj):
         """Update the devices objects."""
         devices = AlexaAPI.get_devices(url, login_obj._session)
         bluetooth = AlexaAPI.get_bluetooth(url, login_obj._session).json()
+
+        if ((devices is None or bluetooth is None)
+                and len(_CONFIGURING) == 0):
+            _LOGGER.debug("Alexa API disconnected; attempting to relogin")
+            login_obj.login_with_cookie()
 
         new_alexa_clients = []
         available_client_ids = []
@@ -215,6 +248,12 @@ def setup_alexa(hass, config, add_devices_callback, login_obj):
             add_devices_callback(new_alexa_clients)
 
     update_devices()
+    # Clear configurator. We delay till here to avoid leaving a modal orphan
+    global _CONFIGURING
+    for config_id in _CONFIGURING:
+        configurator = hass.components.configurator
+        configurator.async_request_done(config_id)
+    _CONFIGURING = []
 
 
 class AlexaClient(MediaPlayerDevice):
@@ -551,24 +590,31 @@ class AlexaClient(MediaPlayerDevice):
 class AlexaLogin():
     """Class to handle login connection to Alexa."""
 
-    def __init__(self, url, email, password, hass):
+    def __init__(self, url, email, password, configpath, debug=False):
         """Set up initial connection and log in."""
-        import pickle
         self._url = url
         self._email = email
         self._password = password
         self._session = None
         self._data = None
         self.status = {}
-        self._cookiefile = hass.config.path("{}.pickle".format(ALEXA_DATA))
-        self._debugpost = hass.config.path("{}post.html".format(ALEXA_DATA))
-        self._debugget = hass.config.path("{}get.html".format(ALEXA_DATA))
+        self._cookiefile = configpath("{}.pickle".format(ALEXA_DATA))
+        self._debugpost = configpath("{}post.html".format(ALEXA_DATA))
+        self._debugget = configpath("{}get.html".format(ALEXA_DATA))
+        self._lastreq = None
+        self._debug = debug
 
+        self.login_with_cookie()
+
+    def login_with_cookie(self):
+        """Attempt to login after loading cookie."""
+        import pickle
         cookies = None
+
         if (self._cookiefile):
             try:
                 _LOGGER.debug(
-                    "Fetching cookie from file {}".format(
+                    "Trying cookie from file {}".format(
                         self._cookiefile))
                 with open(self._cookiefile, 'rb') as myfile:
                     cookies = pickle.load(myfile)
@@ -587,6 +633,7 @@ class AlexaLogin():
         """Remove data related to existing login."""
         self._session = None
         self._data = None
+        self._lastreq = None
         self.status = {}
 
     def get_inputs(self, soup, searchfield={'name': 'signIn'}):
@@ -607,22 +654,21 @@ class AlexaLogin():
         Attempts to get device list, and if unsuccessful login failed
         """
         if self._session is None:
-            site = 'https://www.' + self._url + '/gp/sign-in.html'
-
             '''initiate session'''
+
             self._session = requests.Session()
 
             '''define session headers'''
             self._session.headers = {
                 'User-Agent': ('Mozilla/5.0 (Windows NT 6.3; Win64; x64) '
                                'AppleWebKit/537.36 (KHTML, like Gecko) '
-                               'Chrome/44.0.2403.61 Safari/537.36'),
+                               'Chrome/68.0.3440.106 Safari/537.36'),
                 'Accept': ('text/html,application/xhtml+xml, '
                            'application/xml;q=0.9,*/*;q=0.8'),
-                'Accept-Language': 'en-US,en;q=0.5',
-                'Referer': site
+                'Accept-Language': '*'
             }
             self._session.cookies = cookies
+
         get_resp = self._session.get('https://alexa.' + self._url +
                                      '/api/devices-v2/device')
         # with open(self._debugget, mode='wb') as localfile:
@@ -646,7 +692,8 @@ class AlexaLogin():
         _LOGGER.debug("Logged in.")
         return True
 
-    def login(self, cookies=None, captcha=None, securitycode=None):
+    def login(self, cookies=None, captcha=None, securitycode=None,
+              claimsoption=None, verificationcode=None):
         """Login to Amazon."""
         from bs4 import BeautifulSoup
         import pickle
@@ -672,17 +719,48 @@ class AlexaLogin():
             self._session.headers = {
                 'User-Agent': ('Mozilla/5.0 (Windows NT 6.3; Win64; x64) '
                                'AppleWebKit/537.36 (KHTML, like Gecko) '
-                               'Chrome/44.0.2403.61 Safari/537.36'),
+                               'Chrome/68.0.3440.106 Safari/537.36'),
                 'Accept': ('text/html,application/xhtml+xml, '
                            'application/xml;q=0.9,*/*;q=0.8'),
-                'Accept-Language': 'en-US,en;q=0.5',
-                'Referer': site
+                'Accept-Language': '*'
             }
+
+        if self._lastreq is not None:
+            site = self._lastreq.url
+            _LOGGER.debug("Loaded last request to {} ".format(site))
+            html = self._lastreq.text
+            '''get BeautifulSoup object of the html of the login page'''
+            if self._debug:
+                with open(self._debugget, mode='wb') as localfile:
+                    localfile.write(self._lastreq.content)
+
+            soup = BeautifulSoup(html, 'html.parser')
+            site = soup.find('form').get('action')
+            if site is None:
+                site = self._lastreq.url
+            elif site == 'verify':
+                import re
+                site = re.search(r'(.+)/(.*)',
+                                 self._lastreq.url).groups()[0] + "/verify"
 
         if self._data is None:
             resp = self._session.get(site)
+            self._lastreq = resp
+            if resp.history:
+                _LOGGER.debug("Get to {} was redirected to {}".format(
+                    site,
+                    resp.url))
+                self._session.headers['Referer'] = resp.url
+            else:
+                _LOGGER.debug("Get to {} was not redirected".format(site))
+                self._session.headers['Referer'] = site
+
             html = resp.text
             '''get BeautifulSoup object of the html of the login page'''
+            if self._debug:
+                with open(self._debugget, mode='wb') as localfile:
+                    localfile.write(resp.content)
+
             soup = BeautifulSoup(html, 'html.parser')
             '''scrape login page to get all the inputs required for login'''
             self._data = self.get_inputs(soup)
@@ -693,49 +771,86 @@ class AlexaLogin():
         '''add username and password to the data for post request'''
         '''check if there is an input field'''
         if "email" in self._data:
-            self._data[u'email'] = self._email
+            self._data['email'] = self._email.encode('utf-8')
         if "password" in self._data:
-            self._data[u'password'] = self._password
+            self._data['password'] = self._password.encode('utf-8')
         if "rememberMe" in self._data:
-            self._data[u'rememberMe'] = "true"
+            self._data['rememberMe'] = "true".encode('utf-8')
 
         status = {}
-        _LOGGER.debug("Captcha: {} SecurityCode: {}".format(captcha,
-                                                            securitycode))
+        _LOGGER.debug(("Preparing post to {} Captcha: {}"
+                       " SecurityCode: {} Claimsoption: {} "
+                       "VerificationCode: {}").format(
+            site,
+            captcha,
+            securitycode,
+            claimsoption,
+            verificationcode
+            ))
         if (captcha is not None and 'guess' in self._data):
-            self._data[u'guess'] = captcha
+            self._data['guess'] = captcha.encode('utf-8')
         if (securitycode is not None and 'otpCode' in self._data):
-            self._data[u'otpCode'] = securitycode
-            self._data[u'rememberDevice'] = "true"
-            self._data[u'mfaSubmit'] = "true"
+            self._data['otpCode'] = securitycode.encode('utf-8')
+            self._data['rememberDevice'] = ""
+        if (claimsoption is not None and 'option' in self._data):
+            self._data['option'] = claimsoption.encode('utf-8')
+        if (verificationcode is not None and 'code' in self._data):
+            self._data['code'] = verificationcode.encode('utf-8')
+        self._session.headers['Content-Type'] = ("application/x-www-form-"
+                                                 "urlencoded; charset=utf-8")
+        self._data.pop('', None)
 
-        # _LOGGER.debug("Submit Form Data: {}".format(self._data))
+        if self._debug:
+            _LOGGER.debug("Cookies: {}".format(self._session.cookies))
+            _LOGGER.debug("Submit Form Data: {}".format(self._data))
+            _LOGGER.debug("Header: {}".format(self._session.headers))
 
         '''submit post request with username/password and other needed info'''
         post_resp = self._session.post(site, data=self._data)
-        # with open(self._debugpost, mode='wb') as localfile:
-        #     localfile.write(post_resp.content)
+        self._session.headers['Referer'] = site
+
+        self._lastreq = post_resp
+        if self._debug:
+            with open(self._debugpost, mode='wb') as localfile:
+                localfile.write(post_resp.content)
 
         post_soup = BeautifulSoup(post_resp.content, 'html.parser')
 
-        captcha_tag = post_soup.find(id="auth-captcha-image")
-        securitycode_tag = post_soup.find(id="auth-mfa-otpcode")
         login_tag = post_soup.find('form', {'name': 'signIn'})
+        captcha_tag = post_soup.find(id="auth-captcha-image")
 
-        '''another login required? try once more. This appears necessary as
-        the first login fails for alexa's login site for some reason
+        '''another login required and no captcha request? try once more.
+        This is a necessary hack as the first attempt always fails.
+        TODO: Figure out how to remove this hack
         '''
-        if login_tag is not None:
+        if (login_tag is not None and captcha_tag is None):
             login_url = login_tag.get("action")
-            _LOGGER.debug("Login requested again; retrying once: {}".format(
+            _LOGGER.debug("Performing second login to: {}".format(
                 login_url))
             post_resp = self._session.post(login_url,
                                            data=self._data)
-            # with open(self._debugpost, mode='wb') as localfile:
-            #     localfile.write(post_resp.content)
+            if self._debug:
+                with open(self._debugpost, mode='wb') as localfile:
+                    localfile.write(post_resp.content)
             post_soup = BeautifulSoup(post_resp.content, 'html.parser')
+            login_tag = post_soup.find('form', {'name': 'signIn'})
             captcha_tag = post_soup.find(id="auth-captcha-image")
-            securitycode_tag = post_soup.find(id="auth-mfa-otpcode")
+
+        securitycode_tag = post_soup.find(id="auth-mfa-otpcode")
+        errorbox = (post_soup.find(id="auth-error-message-box")
+                    if post_soup.find(id="auth-error-message-box") else
+                    post_soup.find(id="auth-warning-message-box"))
+        claimspicker_tag = post_soup.find('form', {'name': 'claimspicker'})
+        verificationcode_tag = post_soup.find('form', {'action': 'verify'})
+
+        '''pull out Amazon error message'''
+
+        if errorbox:
+            error_message = errorbox.find('h4').string
+            for li in errorbox.findAll('li'):
+                error_message += li.find('span').string
+            _LOGGER.debug("Error message: {}".format(error_message))
+            status['error_message'] = error_message
 
         if captcha_tag is not None:
             _LOGGER.debug("Captcha requested")
@@ -747,6 +862,34 @@ class AlexaLogin():
             _LOGGER.debug("2FA requested")
             status['securitycode_required'] = True
             self._data = self.get_inputs(post_soup, {'id': 'auth-mfa-form'})
+
+        elif claimspicker_tag is not None:
+            claims_message = ""
+            options_message = ""
+            for div in claimspicker_tag.findAll('div', 'a-row'):
+                claims_message += "{}\n".format(div.string)
+            for label in claimspicker_tag.findAll('label'):
+                value = (label.find('input')['value']) if label.find(
+                    'input') else ""
+                message = (label.find('span').string) if label.find(
+                    'span') else ""
+                valuemessage = ("Option: {} = `{}`.\n".format(
+                    value, message)) if value != "" else ""
+                options_message += valuemessage
+            _LOGGER.debug("Verification method requested: {}".format(
+                claims_message, options_message))
+            status['claimspicker_required'] = True
+            status['claimspicker_message'] = options_message
+            self._data = self.get_inputs(post_soup, {'name': 'claimspicker'})
+        elif verificationcode_tag is not None:
+            _LOGGER.debug("Verification code requested:")
+            status['verificationcode_required'] = True
+            self._data = self.get_inputs(post_soup, {'action': 'verify'})
+        elif login_tag is not None:
+            login_url = login_tag.get("action")
+            _LOGGER.debug("Another login requested to: {}".format(
+                login_url))
+            status['login_failed'] = True
 
         else:
             _LOGGER.debug("Captcha/2FA not requested; confirming login.")
@@ -767,6 +910,7 @@ class AlexaLogin():
                                 message))
             else:
                 _LOGGER.debug("Login failed; check credentials")
+                status['login_failed'] = True
 
         self.status = status
 


### PR DESCRIPTION
Should resolve #33.

Also minor fixes:
- Add debug option - This adds a debug option for sensitive data. It will actually write debug html files to the config directory and output emails/passwords to the debug log. While I recognize HA already has logger debug levels, I wasn't comfortable shipping a default version that would log passwords into HA. Should be easy to rip out, but I'm forced to manually add it in when I debug so I'd prefer to keep it.
- Fix modal orphan bug - This happens when we done a configurator before it closes.
- Capture Amazon error message to log and configurator
- Detect later Amazon login failure and automatically attempt relogin. Should address PR #32.
- Refactor login status testing code
- Minor fixes like updating user-agent