### PR TITLE
Add volume adjustment while in standby

### DIFF
--- a/media_player/alexa.py
+++ b/media_player/alexa.py
@@ -220,7 +220,7 @@ def setup_alexa(hass, config, add_devices_callback, login_obj):
                 continue
             elif exclude and device['accountName'] in exclude:
                 continue
-                        
+
             for b_state in bluetooth['bluetoothStates']:
                 if device['serialNumber'] == b_state['deviceSerialNumber']:
                     device['bluetooth_state'] = b_state
@@ -506,9 +506,11 @@ class AlexaClient(MediaPlayerDevice):
 
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""
+        if not self.available:
+            return
         if not (self.state in [STATE_PLAYING, STATE_PAUSED]
                 and self.available):
-            return
+            self.alexa_api.send_tts("..............")
         self.alexa_api.set_volume(volume)
         self._media_vol_level = volume
 


### PR DESCRIPTION
This should resolve #43. 

This is done by forcing a TTS for "......." before setting the volume if nothing is detected playing.  When playing a Flash Briefing, there is no media reported, but it appears to successfully change the volume without interrupting the skill.   Tested for US English so it's possible the multiple period may break in another language.