### PR TITLE
fix: handle forgot password page

### DIFF
--- a/custom_components/alexa_media/.translations/en.json
+++ b/custom_components/alexa_media/.translations/en.json
@@ -54,7 +54,10 @@
         "title": "Alexa Media Player - Action Required"
       }
     },
-    "title": "Alexa Media Player"
+    "abort": {
+      "forgot_password": "The Forgot Password page was detected. This normally is the result of too may failed logins. Amazon may require action before a relogin can be attempted.",
+      "login_failed": "Alexa Media Player failed to login."
+    }
   },
   "options": {
     "step": {

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -316,8 +316,9 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                 },
             )
         if login.status and login.status.get("login_failed"):
-            _LOGGER.debug("Login failed")
-            return self.async_abort(reason="Login failed")
+            _LOGGER.debug("Login failed: %s", login.status.get("login_failed"))
+            await login.close()
+            return self.async_abort(reason=login.status.get("login_failed"),)
         new_schema = self._update_ord_dict(
             self.data_schema,
             {

--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -6,5 +6,5 @@
   "issue_tracker": "https://github.com/custom-components/alexa_media_player/issues",
   "dependencies": ["configurator"],
   "codeowners": ["@keatontaylor", "@alandtse"],
-  "requirements": ["alexapy==1.12.1"]
+  "requirements": ["alexapy==1.12.2"]
 }

--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -54,7 +54,10 @@
         "title": "Alexa Media Player - Action Required"
       }
     },
-    "title": "Alexa Media Player"
+    "abort": {
+      "forgot_password": "The Forgot Password page was detected. Amazon may require action before a relogin can be attempted.",
+      "login_failed": "Alexa Media Player failed to login."
+    }
   },
   "options": {
     "step": {


### PR DESCRIPTION
This happens if Amazon detects too many bad logins. Further action may
be required from the user before trying to login again.