### PR TITLE
Fixed issue where async updates were not processed correctly

### DIFF
--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -500,7 +500,7 @@ class AlexaMediaNotificationSensor(Entity):
         account_dict = self.hass.data[DATA_ALEXAMEDIA]["accounts"][self._account]
         self._timestamp = account_dict["notifications"]["process_timestamp"]
         try:
-            self._n_dict = account_dict["notifications"][self._dev_id][self._type]
+            self._n_dict = account_dict["notifications"][self._client.device_serial_number][self._type]
         except KeyError:
             self._n_dict = None
         self._process_raw_notifications()


### PR DESCRIPTION
Where multiple instances of the component are in use, the `_dev_id` is made up from a combination of the serial number & account email address. This was being used when trying to read the notifications for the device as part of the `async_update` call.

This resulted in an alarm time being correctly setup when the integration was reloaded, but then cancelled the next time an async update occurred. 

```
homeassistant_1    | 2021-10-08 23:06:09 DEBUG (MainThread) [custom_components.alexa_media.sensor] <Entity Echo Dot next Alarm: 2021-10-11T07:05:00+01:00>: Scheduling event in 2 days, 7:58:50.590271
homeassistant_1    | 2021-10-08 23:06:09 DEBUG (MainThread) [custom_components.alexa_media.sensor] <Entity Echo Dot next Alarm: unavailable>: Cancelling old event
```

This PR changes the read from the notification map to use the serial number of the device instead of the computed unique id for the device. 