### PR TITLE
fix: spotify playback progress bar display

### DIFF
--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -432,7 +432,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                     # Get and set mediaProgress only when mediaLength is obtained.
                     # Fixed an issue where mediaLength was sometimes acquired as 0 on Spotify etc.,
                     # causing the progress bar to disappear.
-                    if player_info.get("progress", {}).get("mediaProgress"):
+                    if player_info.get("progress", {}).get("mediaProgress") is not None:
                         player_info["progress"]["mediaProgress"] = int(
                             player_info["progress"]["mediaProgress"] / 1000
                         )


### PR DESCRIPTION
This fixes issue #3042 Spotify playback progress bar not displayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed playback progress tracking so the progress indicator is only updated after the media duration is known. This prevents the progress bar from disappearing on certain streaming services (notably Spotify) and ensures progress syncs correctly without altering other playback state or artwork handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->