### PR TITLE
fix: airQualitySensor to use HA classes

### DIFF
--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -144,8 +144,20 @@ ALEXA_ICON_CONVERSION = {
     "Alexa.AirQuality.CarbonMonoxide": "mdi:molecule-co",
     "Alexa.AirQuality.Humidity": "mdi:water-percent",
     "Alexa.AirQuality.IndoorAirQuality": "mdi:numeric",
+    "Alexa.AirQuality.ParticulateMatter": "mdi:blur",
+    "Alexa.AirQuality.VolatileOrganicCompounds": "mdi:air-filter",
 }
 ALEXA_ICON_DEFAULT = "mdi:molecule"
+
+# Device class mapping for air quality sensors
+# Maps Alexa sensor types to Home Assistant SensorDeviceClass
+ALEXA_AIR_QUALITY_DEVICE_CLASS = {
+    "Alexa.AirQuality.ParticulateMatter": "pm25",
+    "Alexa.AirQuality.CarbonMonoxide": "carbon_monoxide",
+    "Alexa.AirQuality.IndoorAirQuality": "aqi",
+    "Alexa.AirQuality.VolatileOrganicCompounds": "volatile_organic_compounds",
+    "Alexa.AirQuality.Humidity": "humidity",
+}
 
 UPLOAD_PATH = "www/alexa_tts"
 

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -40,6 +40,7 @@ from .alexa_entity import (
     parse_temperature_from_coordinator,
 )
 from .const import (
+    ALEXA_AIR_QUALITY_DEVICE_CLASS,
     ALEXA_ICON_CONVERSION,
     ALEXA_ICON_DEFAULT,
     ALEXA_UNIT_CONVERSION,
@@ -341,7 +342,7 @@ class AirQualitySensor(SensorEntity, CoordinatorEntity):
             " " + char if char.isupper() else char.strip() for char in self._sensor_name
         ).strip()
         self._attr_name = name + " " + self._sensor_name
-        self._attr_device_class = self._sensor_name  # TODO Fix device class
+        self._attr_device_class = ALEXA_AIR_QUALITY_DEVICE_CLASS.get(sensor_name)
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_value: Optional[datetime.datetime] = (
             parse_air_quality_from_coordinator(coordinator, entity_id, instance)

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -5,7 +5,9 @@ from datetime import timedelta
 import pytest
 
 from custom_components.alexa_media.const import (
+    ALEXA_AIR_QUALITY_DEVICE_CLASS,
     ALEXA_COMPONENTS,
+    ALEXA_ICON_CONVERSION,
     CONF_ACCOUNTS,
     CONF_DEBUG,
     CONF_EXCLUDE_DEVICES,
@@ -171,3 +173,53 @@ class TestConstants:
 
         for const in constants_to_check:
             assert const is not None
+
+
+class TestAirQualityConstants:
+    """Test air quality sensor constants."""
+
+    def test_air_quality_device_class_mapping_exists(self):
+        """Test that ALEXA_AIR_QUALITY_DEVICE_CLASS is defined and is a dict."""
+        assert ALEXA_AIR_QUALITY_DEVICE_CLASS is not None
+        assert isinstance(ALEXA_AIR_QUALITY_DEVICE_CLASS, dict)
+
+    def test_air_quality_device_class_has_required_mappings(self):
+        """Test that all required air quality sensor types have device class mappings."""
+        required_sensors = [
+            "Alexa.AirQuality.ParticulateMatter",
+            "Alexa.AirQuality.CarbonMonoxide",
+            "Alexa.AirQuality.IndoorAirQuality",
+            "Alexa.AirQuality.VolatileOrganicCompounds",
+            "Alexa.AirQuality.Humidity",
+        ]
+        for sensor_type in required_sensors:
+            assert sensor_type in ALEXA_AIR_QUALITY_DEVICE_CLASS
+            assert ALEXA_AIR_QUALITY_DEVICE_CLASS[sensor_type] is not None
+            assert isinstance(ALEXA_AIR_QUALITY_DEVICE_CLASS[sensor_type], str)
+
+    def test_air_quality_device_class_values(self):
+        """Test that device class values match Home Assistant conventions."""
+        expected_mappings = {
+            "Alexa.AirQuality.ParticulateMatter": "pm25",
+            "Alexa.AirQuality.CarbonMonoxide": "carbon_monoxide",
+            "Alexa.AirQuality.IndoorAirQuality": "aqi",
+            "Alexa.AirQuality.VolatileOrganicCompounds": "volatile_organic_compounds",
+            "Alexa.AirQuality.Humidity": "humidity",
+        }
+        for sensor_type, expected_device_class in expected_mappings.items():
+            assert ALEXA_AIR_QUALITY_DEVICE_CLASS[sensor_type] == expected_device_class
+
+    def test_air_quality_icon_mappings_exist(self):
+        """Test that all air quality sensor types have icon mappings."""
+        required_sensors = [
+            "Alexa.AirQuality.ParticulateMatter",
+            "Alexa.AirQuality.CarbonMonoxide",
+            "Alexa.AirQuality.IndoorAirQuality",
+            "Alexa.AirQuality.VolatileOrganicCompounds",
+            "Alexa.AirQuality.Humidity",
+        ]
+        for sensor_type in required_sensors:
+            assert sensor_type in ALEXA_ICON_CONVERSION
+            assert ALEXA_ICON_CONVERSION[sensor_type] is not None
+            assert isinstance(ALEXA_ICON_CONVERSION[sensor_type], str)
+            assert ALEXA_ICON_CONVERSION[sensor_type].startswith("mdi:")


### PR DESCRIPTION
AirQualitySensor was assigning processed sensor names (e.g., "Particulate Matter") as device classes instead of using Home Assistant's standard device class identifiers.

## Changes

**Added device class mapping** (`const.py`)
- Created `ALEXA_AIR_QUALITY_DEVICE_CLASS` dictionary mapping Alexa sensor types to HA device classes:
  - `ParticulateMatter` → `"pm25"`
  - `CarbonMonoxide` → `"carbon_monoxide"`
  - `IndoorAirQuality` → `"aqi"`
  - `VolatileOrganicCompounds` → `"volatile_organic_compounds"`
  - `Humidity` → `"humidity"`

**Updated AirQualitySensor** (`sensor.py`)
```python
# Before
self._attr_device_class = self._sensor_name  # "Particulate Matter"

# After  
self._attr_device_class = ALEXA_AIR_QUALITY_DEVICE_CLASS.get(sensor_name)  # "pm25"
```

**Added icon mappings** (`const.py`)
- `ParticulateMatter`: `mdi:blur`
- `VolatileOrganicCompounds`: `mdi:air-filter`

**Added test coverage** (`test_const.py`)
- Validates all sensor types have correct device class and icon mappings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for particulate matter and volatile organic compounds air quality sensors with improved Home Assistant UI categorization.
  * Enhanced icon mappings for air quality sensor types.

* **Tests**
  * Added comprehensive test coverage for air quality sensor configurations and device class mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->