### PR TITLE
revert: "make should_get_network a user configurable option"

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -67,7 +67,6 @@ from .const import (
     CONF_OTPSECRET,
     CONF_PUBLIC_URL,
     CONF_QUEUE_DELAY,
-    CONF_SHOULD_GET_NETWORK,
     DATA_ALEXAMEDIA,
     DATA_LISTENER,
     DEFAULT_EXTENDED_ENTITY_DISCOVERY,
@@ -109,7 +108,6 @@ ACCOUNT_CONFIG_SCHEMA = vol.Schema(
         vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL): cv.time_period,
         vol.Optional(CONF_QUEUE_DELAY, default=DEFAULT_QUEUE_DELAY): cv.positive_float,
         vol.Optional(CONF_EXTENDED_ENTITY_DISCOVERY, default=False): cv.boolean,
-        vol.Optional(CONF_SHOULD_GET_NETWORK, default=False): cv.boolean,
         vol.Optional(CONF_DEBUG, default=False): cv.boolean,
     }
 )
@@ -193,7 +191,6 @@ async def async_setup(hass, config, discovery_info=None):
                             CONF_EXTENDED_ENTITY_DISCOVERY: account[
                                 CONF_EXTENDED_ENTITY_DISCOVERY
                             ],
-                            CONF_SHOULD_GET_NETWORK: account[CONF_SHOULD_GET_NETWORK],
                             CONF_DEBUG: account[CONF_DEBUG],
                         },
                     )
@@ -219,7 +216,6 @@ async def async_setup(hass, config, discovery_info=None):
                         CONF_EXTENDED_ENTITY_DISCOVERY: account[
                             CONF_EXTENDED_ENTITY_DISCOVERY
                         ],
-                        CONF_SHOULD_GET_NETWORK: account[CONF_SHOULD_GET_NETWORK],
                         CONF_DEBUG: account[CONF_DEBUG],
                     },
                 )
@@ -334,7 +330,7 @@ async def async_setup_entry(hass, config_entry):
             "http2": None,
             "auth_info": None,
             "second_account_index": 0,
-            #            "should_get_network": True,
+            "should_get_network": True,
             "options": {
                 CONF_INCLUDE_DEVICES: config_entry.data.get(CONF_INCLUDE_DEVICES, ""),
                 CONF_EXCLUDE_DEVICES: config_entry.data.get(CONF_EXCLUDE_DEVICES, ""),
@@ -349,9 +345,6 @@ async def async_setup_entry(hass, config_entry):
                 ),
                 CONF_EXTENDED_ENTITY_DISCOVERY: config_entry.data.get(
                     CONF_EXTENDED_ENTITY_DISCOVERY, DEFAULT_EXTENDED_ENTITY_DISCOVERY
-                ),
-                CONF_SHOULD_GET_NETWORK: config_entry.data.get(
-                    CONF_SHOULD_GET_NETWORK, DEFAULT_EXTENDED_ENTITY_DISCOVERY
                 ),
                 CONF_DEBUG: config_entry.data.get(CONF_DEBUG, False),
             },
@@ -440,12 +433,12 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
         ].values()
         auth_info = hass.data[DATA_ALEXAMEDIA]["accounts"][email].get("auth_info")
         new_devices = hass.data[DATA_ALEXAMEDIA]["accounts"][email]["new_devices"]
+        should_get_network = hass.data[DATA_ALEXAMEDIA]["accounts"][email][
+            "should_get_network"
+        ]
         extended_entity_discovery = hass.data[DATA_ALEXAMEDIA]["accounts"][email][
             "options"
         ].get(CONF_EXTENDED_ENTITY_DISCOVERY)
-        should_get_network = hass.data[DATA_ALEXAMEDIA]["accounts"][email][
-            "options"
-        ].get(CONF_SHOULD_GET_NETWORK)
 
         devices = {}
         bluetooth = {}

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -65,7 +65,6 @@ from .const import (
     CONF_PUBLIC_URL,
     CONF_QUEUE_DELAY,
     CONF_SECURITYCODE,
-    CONF_SHOULD_GET_NETWORK,
     CONF_TOTP_REGISTER,
     DATA_ALEXAMEDIA,
     DEFAULT_DEBUG,
@@ -74,7 +73,6 @@ from .const import (
     DEFAULT_PUBLIC_URL,
     DEFAULT_QUEUE_DELAY,
     DEFAULT_SCAN_INTERVAL,
-    DEFAULT_SHOULD_GET_NETWORK,
     DOMAIN,
     ISSUE_URL,
     STARTUP,
@@ -147,7 +145,6 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                 (vol.Optional(CONF_SCAN_INTERVAL, default=60), int),
                 (vol.Optional(CONF_QUEUE_DELAY, default=1.5), float),
                 (vol.Optional(CONF_EXTENDED_ENTITY_DISCOVERY, default=False), bool),
-                (vol.Optional(CONF_SHOULD_GET_NETWORK, default=False), bool),
                 (vol.Optional(CONF_DEBUG, default=False), bool),
             ]
         )
@@ -255,16 +252,6 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                         default=self.config.get(
                             CONF_EXTENDED_ENTITY_DISCOVERY,
                             DEFAULT_EXTENDED_ENTITY_DISCOVERY,
-                        ),
-                    ),
-                    bool,
-                ),
-                (
-                    vol.Optional(
-                        CONF_SHOULD_GET_NETWORK,
-                        default=self.config.get(
-                            CONF_SHOULD_GET_NETWORK,
-                            DEFAULT_SHOULD_GET_NETWORK,
                         ),
                     ),
                     bool,
@@ -823,8 +810,6 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
             self.config[CONF_EXTENDED_ENTITY_DISCOVERY] = user_input[
                 CONF_EXTENDED_ENTITY_DISCOVERY
             ]
-        if CONF_SHOULD_GET_NETWORK in user_input:
-            self.config[CONF_SHOULD_GET_NETWORK] = user_input[CONF_SHOULD_GET_NETWORK]
         if CONF_DEBUG in user_input:
             self.config[CONF_DEBUG] = user_input[CONF_DEBUG]
 
@@ -869,13 +854,6 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                     default=self.config.get(
                         CONF_EXTENDED_ENTITY_DISCOVERY,
                         DEFAULT_EXTENDED_ENTITY_DISCOVERY,
-                    ),
-                ): bool,
-                vol.Optional(
-                    CONF_SHOULD_GET_NETWORK,
-                    default=self.config.get(
-                        CONF_SHOULD_GET_NETWORK,
-                        DEFAULT_SHOULD_GET_NETWORK,
                     ),
                 ): bool,
                 vol.Optional(
@@ -955,16 +933,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         default=self.config_entry.data.get(
                             CONF_EXTENDED_ENTITY_DISCOVERY,
                             DEFAULT_EXTENDED_ENTITY_DISCOVERY,
-                        ),
-                    ),
-                    bool,
-                ),
-                (
-                    vol.Optional(
-                        CONF_SHOULD_GET_NETWORK,
-                        default=self.config_entry.data.get(
-                            CONF_SHOULD_GET_NETWORK,
-                            DEFAULT_SHOULD_GET_NETWORK,
                         ),
                     ),
                     bool,

--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -49,7 +49,6 @@ CONF_EXCLUDE_DEVICES = "exclude_devices"
 CONF_QUEUE_DELAY = "queue_delay"
 CONF_PUBLIC_URL = "public_url"
 CONF_EXTENDED_ENTITY_DISCOVERY = "extended_entity_discovery"
-CONF_SHOULD_GET_NETWORK = "should_get_network"
 CONF_SECURITYCODE = "securitycode"
 CONF_OTPSECRET = "otp_secret"
 CONF_PROXY = "proxy"
@@ -62,7 +61,6 @@ EXCEPTION_TEMPLATE = "An exception of type {0} occurred. Arguments:\n{1!r}"
 
 DEFAULT_DEBUG = False
 DEFAULT_EXTENDED_ENTITY_DISCOVERY = False
-DEFAULT_SHOULD_GET_NETWORK = False
 DEFAULT_HASS_URL = "http://homeassistant.local:8123"
 DEFAULT_PUBLIC_URL = ""
 DEFAULT_QUEUE_DELAY = 1.5

--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -10,7 +10,7 @@
       "identifier_exists": "Email for Alexa URL already registered",
       "invalid_credentials": "Invalid credentials",
       "invalid_url": "URL is invalid: {message}",
-      "2fa_key_invalid": "{otp_secret} is invalid.  It must be a verified 52-character Authenticator App key for Amazon 2SV.",
+      "2fa_key_invalid": "Invalid Authenticator App key for Amazon 2SV",
       "unable_to_connect_hass_url": "Unable to connect to Home Assistant Local URL. Please check the URL under Settings > System > Network > Home Assistant URL > Local network",
       "unknown_error": "Unknown error: {message}"
     },
@@ -29,7 +29,6 @@
           "scan_interval": "Scheduled polling interval (seconds)",
           "queue_delay": "Delay to queue multiple commands together (seconds)",
           "extended_entity_discovery": "Include devices connected via Echo",
-          "should_get_network": "Discover Alexa network",
           "debug": "Advanced debugging"
         },
         "description": "Required *",
@@ -61,7 +60,6 @@
           "scan_interval": "Scheduled polling frequency (seconds)",
           "queue_delay": "Delay to queue multiple commands together (seconds)",
           "extended_entity_discovery": "Include devices connected via Echo",
-          "should_get_network": "Discover Alexa network",
           "debug": "Advanced debugging"
         },
         "description": "Required *",


### PR DESCRIPTION
Reverts alandtse/alexa_media_player#3057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the "Discover Alexa network" configuration option from setup and options interfaces. Network discovery is now automatically enabled by default for all accounts, streamlining configuration.
  * Improved error messaging for invalid two-factor authentication keys to provide clearer feedback during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->