### PR TITLE
fix: reauth flow without a link to the config entry

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -33,7 +33,7 @@ from homeassistant.components.persistent_notification import (
     async_create as async_create_persistent_notification,
     async_dismiss as async_dismiss_persistent_notification,
 )
-from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_REAUTH
 from homeassistant.const import (
     CONF_EMAIL,
     CONF_NAME,
@@ -1579,7 +1579,11 @@ async def test_login_status(hass, config_entry, login) -> bool:
             CONF_OTPSECRET: account.get(CONF_OTPSECRET, ""),
         },
     )
-    hass.data[DATA_ALEXAMEDIA]["config_flows"][
-        f"{account[CONF_EMAIL]} - {account[CONF_URL]}"
-    ] = config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}).__next__()
+    try:
+        flow_obj = config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}).__next__()
+        hass.data[DATA_ALEXAMEDIA]["config_flows"][
+            f"{account[CONF_EMAIL]} - {account[CONF_URL]}"
+        ] = flow_obj
+    except StopIteration:
+        _LOGGER.debug("A new config flow could not be created.")
     return False


### PR DESCRIPTION
This fixes #3073.

I have confirmed that the force logout and then re-authentication flow works fine.

Log is:
```log
2025-11-09 11:07:46.614 DEBUG (MainThread) [custom_components.alexa_media.services] Service force_logout called for: ['xxx@xxx(masked)']
2025-11-09 11:07:46.618 WARNING (MainThread) [alexapy.helpers] alexaapi.force_logout((), {}): An error occurred accessing AlexaAPI: An exception of type AlexapyLoginError occurred. Arguments:
('Forced Logout',)
2025-11-09 11:07:46.618 DEBUG (MainThread) [custom_components.alexa_media.helpers] Reporting need to relogin to amazon.co.jp with s***********u@g*******m stats: {'login_timestamp': datetime.datetime(2025, 11, 9, 11, 5, 2, 879968), 'api_calls': 38}
2025-11-09 11:07:46.619 DEBUG (MainThread) [custom_components.alexa_media] s***********u@g*******m: Received relogin request: <Event alexa_media_relogin_required[L]: email=s***********u@g*******m, url=amazon.co.jp, stats=login_timestamp=2025-11-09T11:05:02.879968+09:00, api_calls=38>
2025-11-09 11:07:46.624 DEBUG (MainThread) [custom_components.alexa_media.helpers] s***********u@g*******m: Returning uuid {'uuid': 'xxx', 'index': 0}
2025-11-09 11:07:46.625 DEBUG (MainThread) [alexapy.alexalogin] Resetting Login for xxx@xxx(masked) - amazon.co.jp
2025-11-09 11:07:46.629 DEBUG (MainThread) [custom_components.alexa_media] Testing login status: {}
2025-11-09 11:07:46.629 DEBUG (MainThread) [custom_components.alexa_media] Logging in: {'debug': False, 'email': 's***********u@g*******m', 'exclude_devices': '', 'extended_entity_discovery': False, 'include_devices': '', 'oauth': {'access_token': 'A*****************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************1Nt', 'refresh_token': 'A*****************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************_7_', 'expires_in': 1762657501.572982, 'mac_dms': {'device_private_key': '(masked)', 'adp_token': '{enc:(masked)}{serial:Mg==}'}, 'code_verifier': 'xxx', 'authorization_code': 'xxx'}, 'otp_secret': 'M************************************************EFA', 'password': 'REDACTED 11 CHARS', 'public_url': '/', 'queue_delay': 1.5, 'scan_interval': 60, 'url': 'amazon.co.jp'} set()
2025-11-09 11:07:46.630 DEBUG (MainThread) [custom_components.alexa_media] Login stats: {'login_timestamp': datetime.datetime(2025, 11, 9, 11, 5, 2, 879968), 'api_calls': 38}
2025-11-09 11:07:46.631 DEBUG (MainThread) [custom_components.alexa_media] Creating new config flow to login
2025-11-09 11:07:46.636 DEBUG (MainThread) [custom_components.alexa_media.config_flow] Creating reauth form with OrderedDict({'otp_secret': 'M************************************************EFA', 'email': 's***********u@g*******m', 'password': 'REDACTED 11 CHARS', 'url': 'amazon.co.jp', 'public_url': '/', 'scan_interval': 60, 'queue_delay': 1.5, 'include_devices': '', 'exclude_devices': '', 'extended_entity_discovery': False, 'debug': False, 'reauth': True})
2025-11-09 11:07:46.637 DEBUG (MainThread) [custom_components.alexa_media.config_flow] Attempting automatic relogin
2025-11-09 11:08:01.639 DEBUG (MainThread) [custom_components.alexa_media.config_flow] Using existing login
2025-11-09 11:08:01.640 DEBUG (MainThread) [custom_components.alexa_media.config_flow] Trying to login {}
2025-11-09 11:08:01.640 DEBUG (MainThread) [alexapy.alexalogin] Using credentials to log in
2025-11-09 11:08:01.641 DEBUG (MainThread) [alexapy.alexalogin] Attempting oauth login to https://www.amazon.com/ap/register?openid.return_to=https://www.amazon.com/ap/maplanding&openid.assoc_handle=amzn_dp_project_dee_ios&openid.identity=http://specs.openid.net/auth/2.0/identifier_select&pageId=amzn_dp_project_dee_ios&accountStatusPolicy=P1&openid.claimed_id=http://specs.openid.net/auth/2.0/identifier_select&openid.mode=checkid_setup&openid.ns.oa2=http://www.amazon.com/ap/ext/oauth/2&openid.oa2.client_id=device:xxx&openid.ns.pape=http://specs.openid.net/extensions/pape/1.0&openid.oa2.response_type=code&openid.ns=http://specs.openid.net/auth/2.0&openid.pape.max_auth_age=0&openid.oa2.scope=device_auth_access+offline_access&openid.oa2.code_challenge_method=S256&openid.oa2.code_challenge=xxx&language=ja_JP
2025-11-09 11:08:01.993 DEBUG (MainThread) [alexapy.alexalogin] GET: 
https://www.amazon.com/ap/register?openid.return_to=https://www.amazon.com/ap/maplanding&openid.assoc_handle=amzn_dp_project_dee_ios&openid.identity=http://specs.openid.net/auth/2.0/identifier_select&pageId=amzn_dp_project_dee_ios&accountStatusPolicy=P1&openid.claimed_id=http://specs.openid.net/auth/2.0/identifier_select&openid.mode=checkid_setup&openid.ns.oa2=http://www.amazon.com/ap/ext/oauth/2&openid.oa2.client_id=device:xxx&openid.ns.pape=http://specs.openid.net/extensions/pape/1.0&openid.oa2.response_type=code&openid.ns=http://specs.openid.net/auth/2.0&openid.pape.max_auth_age=0&openid.oa2.scope=device_auth_access+offline_access&openid.oa2.code_challenge_method=S256&openid.oa2.code_challenge=xxx&language=ja_JP returned 200:OK with response <CIMultiDictProxy('Server': 'Server', 'Content-Type': 'text/html;charset=UTF-8', 'x-amz-rid': 'xxx', 'X-XSS-Protection': '1', 'X-Content-Type-Options': 'nosniff', 'X-Frame-Options': 'SAMEORIGIN', 'x-ua-compatible': 'IE=edge', 'Pragma': 'No-cache', 'Cache-Control': 'max-age=0, no-cache, no-store, must-revalidate', 'Expires': 'Thu, 01 Jan 1970 00:00:00 GMT', 'Content-Security-Policy': "frame-ancestors 'none';", 'Content-Encoding': 'gzip', 'Content-Language': 'und', 'Vary': 'accept-encoding,Content-Type,x-amz-opf-internal-weblab-AUTHX-HZ-MIGRATION-REGISTER-RESIDUAL-TRAFFIC-1319638,Accept-Encoding,User-Agent', 'Strict-Transport-Security': 'max-age=47474747; includeSubDomains; preload', 'Date': 'Sun, 09 Nov 2025 02:08:01 GMT', 'Transfer-Encoding': 'chunked', 'Connection': 'keep-alive', 'Connection': 'Transfer-Encoding', 'Set-Cookie': 'lc-main=ja_JP; Domain=.amazon.com; Expires=Tue, 01 Jan 2036 08:00:01 GMT; Path=/; Secure', 'Set-Cookie': 'session-id=137-4370329-3341261; Domain=.amazon.com; Expires=Tue, 01 Jan 2036 08:00:01 GMT; Path=/; Secure', 'Set-Cookie': 'session-id-time=2082787201l; Domain=.amazon.com; Expires=Tue, 01 Jan 2036 08:00:01 GMT; Path=/; Secure', 'Set-Cookie': 'session-id=141-7693235-1701552; Domain=.amazon.com; Expires=Mon, 09 Nov 2026 02:08:01 GMT; Path=/; Secure', 'Set-Cookie': 'session-id-time=2393374081l; Domain=.amazon.com; Expires=Mon, 09 Nov 2026 02:08:01 GMT; Path=/; Secure', 'Alt-Svc': 'h3=":443"; ma=93600', 'X-Amzn-Cdn-Id': 'ak-0.eb52cd17.1762654081.61e331b4', 'X-Cache': 'NotCacheable from child')>
2025-11-09 11:08:02.021 DEBUG (MainThread) [alexapy.alexalogin] Processing https://www.amazon.com/ap/register?openid.return_to=https://www.amazon.com/ap/maplanding&openid.assoc_handle=amzn_dp_project_dee_ios&openid.identity=http://specs.openid.net/auth/2.0/identifier_select&pageId=amzn_dp_project_dee_ios&accountStatusPolicy=P1&openid.claimed_id=http://specs.openid.net/auth/2.0/identifier_select&openid.mode=checkid_setup&openid.ns.oa2=http://www.amazon.com/ap/ext/oauth/2&openid.oa2.client_id=device:xxx&openid.ns.pape=http://specs.openid.net/extensions/pape/1.0&openid.oa2.response_type=code&openid.ns=http://specs.openid.net/auth/2.0&openid.pape.max_auth_age=0&openid.oa2.scope=device_auth_access+offline_access&openid.oa2.code_challenge_method=S256&openid.oa2.code_challenge=xxx&language=ja_JP
2025-11-09 11:08:02.166 DEBUG (MainThread) [alexapy.alexalogin] Found standard login page
2025-11-09 11:08:02.169 DEBUG (MainThread) [alexapy.alexalogin] Found post url to https://www.amazon.com/ap/register/141-7693235-1701552
2025-11-09 11:08:02.169 DEBUG (MainThread) [alexapy.alexalogin] Preparing form submission to https://www.amazon.com/ap/register/141-7693235-1701552 with input data: OrderedDict({'otp_secret': 'M************************************************EFA', 'email': 's***********u@g*******m', 'password': 'REDACTED 11 CHARS', 'url': 'amazon.co.jp', 'public_url': '/', 'scan_interval': 60, 'queue_delay': 1.5, 'include_devices': '', 'exclude_devices': '', 'extended_entity_discovery': False, 'debug': False, 'reauth': True})
2025-11-09 11:08:02.170 DEBUG (MainThread) [alexapy.alexalogin] Creating TOTP for M************************************************EFA
2025-11-09 11:08:02.170 DEBUG (MainThread) [alexapy.alexalogin] Generating OTP 064961
2025-11-09 11:08:02.171 DEBUG (MainThread) [alexapy.alexalogin] No 2FA code supplied but will generate.
2025-11-09 11:08:02.171 DEBUG (MainThread) [alexapy.alexalogin] Generating OTP 064961
2025-11-09 11:08:02.446 DEBUG (MainThread) [alexapy.alexalogin] POST: 
https://www.amazon.com/ap/register/141-7693235-1701552 returned 200:OK with response <CIMultiDictProxy('Server': 'Server', 'Content-Type': 'text/html;charset=UTF-8', 'x-amz-rid': 'QRYBBSQGW2Z1ABKQ1AZW', 'X-XSS-Protection': '1', 'X-Content-Type-Options': 'nosniff', 'X-Frame-Options': 'SAMEORIGIN', 'x-ua-compatible': 'IE=edge', 'Pragma': 'No-cache', 'Cache-Control': 'max-age=0, no-cache, no-store, must-revalidate', 'Expires': 'Thu, 01 Jan 1970 00:00:00 GMT', 'Content-Security-Policy': "frame-ancestors 'none';", 'Content-Encoding': 'gzip', 'Content-Language': 'und', 'Vary': 'accept-encoding,Content-Type,x-amz-opf-internal-weblab-AUTHX-HZ-MIGRATION-REGISTER-RESIDUAL-TRAFFIC-1319638,Accept-Encoding,User-Agent', 'Strict-Transport-Security': 'max-age=47474747; includeSubDomains; preload', 'Date': 'Sun, 09 Nov 2025 02:08:02 GMT', 'Transfer-Encoding': 'chunked', 'Connection': 'keep-alive', 'Connection': 'Transfer-Encoding', 'Set-Cookie': 'ubid-main=132-3231511-8106465; Domain=.amazon.com; Expires=Tue, 01 Jan 2036 08:00:01 GMT; Path=/; Secure', 'Set-Cookie': 'lc-main=ja_JP; Domain=.amazon.com; Expires=Tue, 01 Jan 2036 08:00:01 GMT; Path=/; Secure', 'Set-Cookie': 'session-id=xxxx; Domain=.amazon.com; Expires=Tue, 01 Jan 2036 08:00:01 GMT; Path=/; Secure', 'Set-Cookie': 'session-id-time=xxx; Domain=.amazon.com; Expires=Tue, 01 Jan 2036 08:00:01 GMT; Path=/; Secure', 'Set-Cookie': 'session-id=xxx; Domain=.amazon.com; Expires=Mon, 09 Nov 2026 02:08:02 GMT; Path=/; Secure', 'Set-Cookie': 'session-id-time=xxx; Domain=.amazon.com; Expires=Mon, 09 Nov 2026 02:08:02 GMT; Path=/; Secure', 'Set-Cookie': 'ubid-main=xxx; Domain=.amazon.com; Expires=Mon, 09 Nov 2026 02:08:02 GMT; Path=/; Secure', 'Alt-Svc': 'h3=":443"; ma=93600', 'X-Amzn-Cdn-Id': 'ak-0.eb52cd17.1762654082.61e33590', 'X-Cache': 'NotCacheable from child')>
2025-11-09 11:08:02.470 DEBUG (MainThread) [alexapy.alexalogin] Processing https://www.amazon.com/ap/register/141-7693235-1701552
2025-11-09 11:08:02.611 DEBUG (MainThread) [alexapy.alexalogin] Found standard login page
2025-11-09 11:08:02.614 DEBUG (MainThread) [alexapy.alexalogin] Found post url to https://www.amazon.com/ap/register
2025-11-09 11:08:02.614 DEBUG (MainThread) [custom_components.alexa_media.config_flow] Testing login status: {}
2025-11-09 11:08:08.965 DEBUG (MainThread) [custom_components.alexa_media.config_flow] Using existing login
2025-11-09 11:08:08.966 DEBUG (MainThread) [alexapy.alexalogin] Creating TOTP for M************************************************EFA
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reauthentication flow handling to ensure reliable credential refresh when Alexa authentication expires.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->