### PR TITLE
chore: change pre-commit ci to run on dev + master branches

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [dev, master]
 
 jobs:
   pre-commit:


### PR DESCRIPTION
I noticed the pre-commit hooks were not running on the branches PR's merge into

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to adjust which development branches trigger automated checks.

---

**Note:** This release contains only internal infrastructure updates with no user-facing changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->