### PR TITLE
build: modify devcontainer to run within home assistant

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,29 +1,21 @@
-# See here for image contents: https://github.com/devcontainers/images/tree/main/src/python
+FROM mcr.microsoft.com/devcontainers/python:2-3.13-bookworm
 
-FROM mcr.microsoft.com/devcontainers/python:3.13-bullseye
+RUN \
+    apt update && \
+    apt install -y iptables iproute2 libturbojpeg0-dev ffmpeg libpcap0.8 curl && \
+    update-alternatives --set iptables /usr/sbin/iptables-legacy
 
-# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="none"
-RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
-# Workaround https://unix.stackexchange.com/questions/2544/how-to-work-around-release-file-expired-problem-on-a-local-mirror
+RUN \
+    case "$(uname -m)" in \
+    x86_64) go2rtc_suffix="amd64" ;; \
+    aarch64) go2rtc_suffix="arm64" ;; \
+    *) echo "Unsupported architecture: $(uname -m)" && exit 1 ;; \
+    esac \
+    && curl -L https://github.com/AlexxIT/go2rtc/releases/download/v1.9.11/go2rtc_linux_${go2rtc_suffix} --output /bin/go2rtc \
+    && chmod +x /bin/go2rtc \
+    && go2rtc --version
 
-# RUN echo "Acquire::Check-Valid-Until \"false\";\nAcquire::Check-Date \"false\";" | cat > /etc/apt/apt.conf.d/10no--check-valid-until
-# RUN apt-get update && apt-get install -y ack
 
-RUN pipx install poetry
-WORKDIR /workspace
-COPY pyproject.toml poetry.lock .pre-commit-config.yaml ./
-RUN poetry update
-
-# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
-# COPY requirements.txt /tmp/pip-tmp/
-# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
-#    && rm -rf /tmp/pip-tmp
-
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
-
-# [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+RUN \
+    pipx install poetry 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
 
   // Use 'postCreateCommand' to run commands after the container is created.
   // "postCreateCommand": "pip3 install --user -r requirements.txt",
-  "postCreateCommand": "poetry update && poetry run pre-commit install",
+  "postCreateCommand": "poetry install && poetry run pre-commit install",
   "containerUser": "vscode",
   "updateRemoteUserUID": true,
   "containerEnv": {

--- a/.devcontainer/develop.sh
+++ b/.devcontainer/develop.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# Start Home Assistant
+poetry run hass -c . --debug

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,11 @@ venv.bak/
 .DS_Store
 coverage.lcov
 custom_components/test
+
+# Home Assistant development config directory
+/home-assistant.log*
+/home-assistant_v2.*
+/.ha_run.lock
+/.HA_VERSION
+/.storage/
+/.cloud/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,11 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run Home Assistant on port 8123",
+      "type": "shell",
+      "command": ".devcontainer/develop.sh",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,0 +1,7 @@
+default_config:
+
+logger:
+  default: info
+  logs:
+    custom_components.alexa_media: debug
+    alexa_media: debug


### PR DESCRIPTION
Previously the provided Devcontainer was just setup to support running the code within a Python environment.

This change extends that to run it within Home Assistant to run the code within a development Home Assistant instance if needed by running the defined task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added default Home Assistant configuration for out-of-the-box functionality.
  * Enabled debug logging for Alexa media components to aid troubleshooting.

* **Chores**
  * Updated development environment setup, dependencies, and helper scripts for improved developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->