### PR TITLE
fix: speaker group status

### DIFF
--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -302,7 +302,6 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
 
     async def init(self, device):
         """Initialize."""
-        # _LOGGER.debug("Initialize AlexaClient with device: %s", device)
         await self.refresh(device, skip_api=True)
 
     async def async_added_to_hass(self):


### PR DESCRIPTION
This fixes issue #2993.

Fixes speaker group status display.

The speaker group status display is no longer displayed because the "clusterMembers" and "parentClusters" data are no longer available from the API. As a workaround, "clusterMembers" is now created from "lemurVolume.memberVolume". However, there are the following limitations:

1. For stereo speakers, only the parent entity will be updated.
2. If a speaker group contains stereo speakers, the parent entity of the stereo configuration will not be updated. Only the individual speakers in the stereo configuration will be updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Speaker group/paired-device support with synchronized per-member playback and session-aware cluster refreshes.
  * Centralized attribute synchronization so media title, artist, album, artwork, position, duration and mute/volume state are populated consistently.

* **Improvements**
  * Per-member volume propagation from session data and conditional gating of extra attribute updates.
  * More robust handling and propagation of parent-state and now-playing updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->