### PR TITLE
fix: `should_get_nework` handling should still process existing `entities_to_monitor` when `get_network_details` returns None

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -523,7 +523,7 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                         # Disregard entities_to_monitor results since we now have full network details
                         if entities_to_monitor:
                             optional_task_results.pop()
-                            entities_to_monitor.clear
+                            entities_to_monitor.clear()
                         alexa_entities = parse_alexa_entities(api_devices)
                         hass.data[DATA_ALEXAMEDIA]["accounts"][email]["devices"].update(
                             alexa_entities


### PR DESCRIPTION
Modified `if should_get_network` block so that `entities_to_monitor` is still popped from tasks and processed when AlexaAPI.get_network_details fails to retrieve a list of endpoints and returns None.

This change requires `alexapy` MR !423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased network discovery timeout from 30s to 60s to better handle API retries.
  * Improved logging and error messages during network discovery for clearer status and retry guidance.
  * Prevented reuse of stale device lists by clearing prior monitoring results when a fresh network is processed.
  * Ensured initial entity state is fetched only after network processing completes; warns when no devices are returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->