### PR TITLE
fix: handle error on fetching notifications in `process_notifications()`

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -729,20 +729,22 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
         return entity_state
 
     async def _fetch_notifications_if_falsy(
-        raw_notifications: dict | None,
+        raw_notifications: dict | None, login_obj
     ) -> dict | None:
         """Fetch notifications if none provided."""
         if raw_notifications:
             return raw_notifications
 
         await asyncio.sleep(4)
-        return AlexaAPI.get_notifications(login_obj)
+        return await AlexaAPI.get_notifications(login_obj)
 
     @_catch_login_errors
     async def process_notifications(login_obj, raw_notifications: dict | None = None):
         """Process raw notifications json."""
         try:
-            raw_notifications = await _fetch_notifications_if_falsy(raw_notifications)
+            raw_notifications = await _fetch_notifications_if_falsy(
+                raw_notifications, login_obj
+            )
             email: str = login_obj.email
             previous = hass.data[DATA_ALEXAMEDIA]["accounts"][email].get(
                 "notifications", {}


### PR DESCRIPTION
Currently, failing to fetch notifications kills the whole update process. This PR handles the fetching-failure case by fixing the debug log.
I tested this on my own homeassistant instance, it fixed the problems described below.
Fixes #3134 and #3137 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification processing with better error handling and graceful recovery to reduce missed or failed notifications.

* **Chores**
  * Streamlined notification retrieval with added delays and clearer logging, improving reliability and diagnostics when fetching and processing notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->