### PR TITLE
fix: notifications API None handling

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -783,7 +783,7 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
         _LOGGER.debug(
             "%s: Updated %s notifications for %s devices at %s",
             hide_email(email),
-            len(raw_notifications),
+            len(raw_notifications) if raw_notifications else 0,
             len(notifications),
             dt.as_local(
                 hass.data[DATA_ALEXAMEDIA]["accounts"][email]["notifications"][


### PR DESCRIPTION
## Description
Fixes a TypeError that occurs when Amazon's notifications API endpoint returns a 400 error, causing `raw_notifications` to be `None`.

## Problem
When the `/api/notifications` endpoint returns a 400 Bad Request, the integration crashes during the debug logging statement at line 786 when attempting to call `len(raw_notifications)` on a `None` value.

**Error:**
```
Error fetching alexa_media data: Error communicating with API: object of type 'NoneType' has no len()
```

## Solution
Added a conditional check to safely handle `None` values by returning 0 when `raw_notifications` is `None`:
```python
len(raw_notifications) if raw_notifications else 0
```

## Impact
- Fixes integration setup failures when Amazon's notifications API is unavailable or returns errors
- Allows devices to be discovered and entities created even when notifications endpoint fails
- No functional changes to actual notification handling logic

## Testing
- Tested with Home Assistant where notifications API was returning 400 errors
- Integration successfully loaded and created all device entities after fix
- No impact on normal operation when notifications API works correctly

## Related
This is a defensive fix that allows the integration to gracefully handle API errors rather than crashing during debug logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling in notification processing to prevent potential runtime failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->