### PR TITLE
docs: change extended_entity_discovery description

### DIFF
--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -33,7 +33,7 @@
           "scan_interval": "Scheduled polling interval (seconds)",
           "queue_delay": "Delay to queue multiple commands together (seconds)",
           "should_get_network": "Discover Alexa network",
-          "extended_entity_discovery": "Include devices connected via Echo",
+          "extended_entity_discovery": "Include additional sensors, switches and lights",
           "debug": "Advanced debugging"
         }
       },
@@ -65,7 +65,7 @@
           "scan_interval": "Scheduled polling frequency (seconds)",
           "queue_delay": "Delay to queue multiple commands together (seconds)",
           "should_get_network": "Discover Alexa network",
-          "extended_entity_discovery": "Include devices connected via Echo",
+          "extended_entity_discovery": "Include additional sensors, switches and lights",
           "debug": "Advanced debugging"
         }
       }


### PR DESCRIPTION
Change description for "extended_entity_discovery" to something more meaningful of what the flag really does.
"Include devices connected via Echo" -> "Include additional sensors, switches and lights"

* **Documentation**
  * Revised configuration option description for "extended_entity_discovery" to more clearly indicate that the flag permits the integration to include additional sensors, switches, and lights in your setup that were found during initial network discovery.
