### PR TITLE
fix: bump alexapy to 1.29.10

### DIFF
--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/alandtse/alexa_media_player/issues",
   "loggers": ["alexapy", "authcaptureproxy"],
-  "requirements": ["alexapy==1.29.9", "packaging>=20.3", "wrapt>=1.14.0"],
+  "requirements": ["alexapy==1.29.10", "packaging>=20.3", "wrapt>=1.14.0"],
   "version": "5.8.0"
 }


### PR DESCRIPTION
Fix Error handling of get_devices_gql()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated alexapy library dependency to version 1.29.10

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->