### PR TITLE
fix: restore alarms/timers/reminders legacy attributes

### DIFF
--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -795,7 +795,6 @@ class AlexaMediaNotificationSensor(SensorEntity):
             }
             return data
 
-
         if self._all:
             # Limit to a few entries so attributes stay small
             attr["brief"] = {

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -775,15 +775,26 @@ class AlexaMediaNotificationSensor(SensorEntity):
                 when_val = dt.as_local(when).isoformat()
             else:
                 when_val = when
-            return {
+
+            # Labels are type-specific in Alexa's payload; resolve to a single generic key.
+            label_key = {
+                "Alarm": "alarmLabel",
+                "Timer": "timerLabel",
+                "Reminder": "reminderLabel",
+            }.get(self._type)
+            label = entry.get(label_key) if label_key else None
+
+            data = {
                 "id": entry.get("id"),
-                "label": entry.get("label"),
+                "label": label,
                 "status": entry.get("status"),
                 "type": entry.get("type"),
                 "version": entry.get("version"),
                 self._sensor_property: when_val,
                 "lastUpdatedDate": entry.get("lastUpdatedDate"),
             }
+            return data
+
 
         if self._all:
             # Limit to a few entries so attributes stay small

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -794,11 +794,9 @@ class AlexaMediaNotificationSensor(SensorEntity):
             # Legacy alias attributes (for backwards compatibility with
             # cards/automations that relied on the previous sorted_* attributes).
             #
-            # Historical behavior exposed the full notification dicts; we cap
-            # to keep state attributes from getting excessively large.
-            cap = 50  # Limit legacy attributes to prevent excessive state size
-            legacy_all = [v for _, v in self._all[:cap]]
-            legacy_active = [v for _, v in self._active[:cap]]
+            # Historical behavior exposed the full notification dicts
+            legacy_all = [v for _, v in self._all]
+            legacy_active = [v for _, v in self._active]
 
             # Generic legacy names
             attr["sorted_all"] = legacy_all

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -372,6 +372,11 @@ class AlexaMediaNotificationSensor(SensorEntity):
     """Representation of Alexa Media sensors."""
 
     _unrecorded_attributes = frozenset({"brief", "sorted_active", "sorted_all"})
+    _LABEL_KEY_MAP = {
+        "Alarm": "alarmLabel",
+        "Timer": "timerLabel",
+        "Reminder": "reminderLabel",
+    }
 
     def __init__(
         self,
@@ -777,11 +782,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
                 when_val = when
 
             # Labels are type-specific in Alexa's payload; resolve to a single generic key.
-            label_key = {
-                "Alarm": "alarmLabel",
-                "Timer": "timerLabel",
-                "Reminder": "reminderLabel",
-            }.get(self._type)
+            label_key = self._LABEL_KEY_MAP.get(self._type)
             label = entry.get(label_key) if label_key else None
 
             data = {
@@ -816,11 +817,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
             # These keys are used by card-alexa-alarms-timers.
             if legacy_active:
                 first = legacy_active[0]
-                label_key = {
-                    "Alarm": "alarmLabel",
-                    "Timer": "timerLabel",
-                    "Reminder": "reminderLabel",
-                }.get(self._type)
+                label_key = self._LABEL_KEY_MAP.get(self._type)
                 if label_key:
                     attr[self._type.lower()] = first.get(label_key)
 

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -780,7 +780,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
                 "label": entry.get("label"),
                 "status": entry.get("status"),
                 "type": entry.get("type"),
-                "version":entry.get("version"),
+                "version": entry.get("version"),
                 self._sensor_property: when_val,
                 "lastUpdatedDate": entry.get("lastUpdatedDate"),
             }
@@ -817,7 +817,9 @@ class AlexaMediaNotificationSensor(SensorEntity):
                     attr.setdefault(self._type.lower(), first.get(label_key))
                     if self._type == "Reminder":
                         # Secondary reminder label (when present)
-                        attr.setdefault("reminder_sub_label", first.get("reminderSubLabel"))
+                        attr.setdefault(
+                            "reminder_sub_label", first.get("reminderSubLabel")
+                        )
         return attr
 
 

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -9,7 +9,7 @@ https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers
 
 import datetime
 import logging
-from typing import Callable, Optional
+from typing import Callable, ClassVar, Optional
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -372,7 +372,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
     """Representation of Alexa Media sensors."""
 
     _unrecorded_attributes = frozenset({"brief", "sorted_active", "sorted_all"})
-    _LABEL_KEY_MAP = {
+    _LABEL_KEY_MAP: ClassVar[dict[str, str]] = {
         "Alarm": "alarmLabel",
         "Timer": "timerLabel",
         "Reminder": "reminderLabel",

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -796,7 +796,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
             #
             # Historical behavior exposed the full notification dicts; we cap
             # to keep state attributes from getting excessively large.
-            cap = getattr(self, "_cap_legacy", 50) or 50
+            cap = 50  # Limit legacy attributes to prevent excessive state size
             legacy_all = [v for _, v in self._all[:cap]]
             legacy_active = [v for _, v in self._active[:cap]]
 

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -801,8 +801,8 @@ class AlexaMediaNotificationSensor(SensorEntity):
             legacy_active = [v for _, v in self._active[:cap]]
 
             # Generic legacy names
-            attr.setdefault("sorted_all", legacy_all)
-            attr.setdefault("sorted_active", legacy_active)
+            attr["sorted_all"] = legacy_all
+            attr["sorted_active"] = legacy_active
 
             # Some consumers expect a single string label for the "next" item.
             # These keys are used by card-alexa-alarms-timers.
@@ -814,12 +814,11 @@ class AlexaMediaNotificationSensor(SensorEntity):
                     "Reminder": "reminderLabel",
                 }.get(self._type)
                 if label_key:
-                    attr.setdefault(self._type.lower(), first.get(label_key))
+                    attr[self._type.lower()] = first.get(label_key)
+
                     if self._type == "Reminder":
                         # Secondary reminder label (when present)
-                        attr.setdefault(
-                            "reminder_sub_label", first.get("reminderSubLabel")
-                        )
+                        attr["reminder_sub_label"] = first.get("reminderSubLabel")
         return attr
 
 

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -371,7 +371,7 @@ class AirQualitySensor(SensorEntity, CoordinatorEntity):
 class AlexaMediaNotificationSensor(SensorEntity):
     """Representation of Alexa Media sensors."""
 
-    _unrecorded_attributes = frozenset({"sorted_active", "sorted_all"})
+    _unrecorded_attributes = frozenset({"brief", "sorted_active", "sorted_all"})
 
     def __init__(
         self,


### PR DESCRIPTION
- Restore legacy attributes `sorted_active`, `sorted_all`.
- Fixes issue [#3249](https://github.com/alandtse/alexa_media_player/issues/3249) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Notification sensor attributes reorganized for clearer, more consistent presentation (a new "brief" summary replaces the previous concise field; legacy sorted views preserved).
  * Sensor serialization now includes per-entry metadata (resolved label and version).

* **Improvements**
  * Adds legacy-capped views to preserve compatibility with existing integrations and UI cards.
  * Exposes type-specific labels for alarms, timers, and reminders plus supplemental reminder sub-labels for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->