### PR TITLE
feat: Add serial_number to device info

### DIFF
--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -1853,7 +1853,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
     def device_info(self):
         """
         Provide the device information mapping used by Home Assistant for this entity.
-        
+
         Returns:
             dict: A mapping containing the device's identification and metadata with keys:
                 - `identifiers`: set containing a (domain, unique_id) tuple

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -1859,7 +1859,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             "model": MODEL_IDS.get(
                 self._device_type, f"{self._device_family} {self._device_type}"
             ),
-            "serial_number": self.unique_id,
+            "serial_number": self.device_serial_number,
             "sw_version": self._software_version,
         }
 

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -1851,7 +1851,18 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
 
     @property
     def device_info(self):
-        """Return the device_info of the device."""
+        """
+        Provide the device information mapping used by Home Assistant for this entity.
+        
+        Returns:
+            dict: A mapping containing the device's identification and metadata with keys:
+                - `identifiers`: set containing a (domain, unique_id) tuple
+                - `name`: device display name
+                - `manufacturer`: device manufacturer (always "Amazon")
+                - `model`: device model string
+                - `serial_number`: device serial number (unique_id)
+                - `sw_version`: software version
+        """
         return {
             "identifiers": {(ALEXA_DOMAIN, self.unique_id)},
             "name": self.name,

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -1859,6 +1859,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             "model": MODEL_IDS.get(
                 self._device_type, f"{self._device_family} {self._device_type}"
             ),
+            "serial_number": self.unique_id,
             "sw_version": self._software_version,
         }
 


### PR DESCRIPTION
- Include Echo device serial number in Device info panel
<img width="240" height="205" alt="image" src="https://github.com/user-attachments/assets/ae4c616d-9986-477a-8091-9a60fe5a001d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device information now includes serial number for Alexa media players to improve device identification and management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->