### PR TITLE
fix: fix "One-time password (OTP)" string

### DIFF
--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -24,7 +24,7 @@
           "url": "Amazon region domain (e.g., amazon.co.uk)",
           "email": "Email Address",
           "password": "Password",
-          "securitycode": "[%key_id:55616596%]",
+          "securitycode": "One-time password (OTP)",
           "otp_secret": "52-character Authenticator App Key for Amazon 2SV",
           "hass_url": "Local network URL to access Home Assistant",
           "public_url": "Public URL shared with external hosted services",


### PR DESCRIPTION
I believe this to be the correct fix for [coderabbitai](https://github.com/apps/coderabbitai) comment:

⚠️ Potential issue | 🔴 Critical

####Fix the key reference format for securitycode field.

The format [%key_id:55616596%] does not match Home Assistant's translation reference syntax. The correct syntax is [%key:scope::path::to::key%] using double colons to separate hierarchy levels (e.g., [%key:common::config_flow::abort::already_configured_device%]).

Either provide an actual translation string for the securitycode field or use the proper HA key reference format. This issue affects all 13 translation files consistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the security code field label for better clarity, changing it from a system placeholder to "One-time password (OTP)".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->