### PR TITLE
fix(helpers): correct filter default value logic in add_devices

### DIFF
--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -37,8 +37,8 @@ async def add_devices(
     exclude_filter: Optional[list[str]] = None,
 ) -> bool:
     """Add devices using add_devices_callback."""
-    include_filter = [] or include_filter
-    exclude_filter = [] or exclude_filter
+    include_filter = include_filter or []
+    exclude_filter = exclude_filter or []
     new_devices = []
     for device in devices:
         if (


### PR DESCRIPTION
The pattern `[] or include_filter` is incorrect because:
- When include_filter is None (the default), this evaluates to None
- The correct pattern is `include_filter or []` which returns []

While the current code happens to work due to how Python evaluates truthiness in the subsequent condition, this is a latent bug that:
1. Makes the code harder to understand and maintain
2. Could break if the filter handling logic is modified
3. Violates the principle of least surprise

Added regression tests to verify filter default value handling works correctly with None, empty lists, and explicit filter values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed device filtering to properly handle filter parameters in all scenarios, preventing errors during device addition operations.

* **Tests**
  * Added comprehensive test coverage for device filter handling to ensure consistent behavior with various filter configurations and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->