### PR TITLE
feat: add stricter Matter bridge detection

### DIFF
--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -74,8 +74,7 @@ def is_known_ha_bridge(appliance: Optional[dict[str, Any]]) -> bool:
         driver_id = safe_get(appliance, ["driverIdentity", "identifier"], "")
         if driver_ns == "AAA" and driver_id == "SonarCloudService":
             interfaces = {
-                cap.get("interfaceName")
-                for cap in appliance.get("capabilities", [])
+                cap.get("interfaceName") for cap in appliance.get("capabilities", [])
             }
             if (
                 "Alexa.Matter.NodeOperationalCredentials.FabricManagement" in interfaces

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -73,9 +73,14 @@ def is_known_ha_bridge(appliance: Optional[dict[str, Any]]) -> bool:
         driver_ns = safe_get(appliance, ["driverIdentity", "namespace"], "")
         driver_id = safe_get(appliance, ["driverIdentity", "identifier"], "")
         if driver_ns == "AAA" and driver_id == "SonarCloudService":
-            if _has_interface(
-                appliance, "Alexa.Matter.NodeOperationalCredentials.FabricManagement"
-            ) or _has_interface(appliance, "Alexa.Commissionable"):
+            interfaces = {
+                cap.get("interfaceName")
+                for cap in appliance.get("capabilities", [])
+            }
+            if (
+                "Alexa.Matter.NodeOperationalCredentials.FabricManagement" in interfaces
+                or "Alexa.Commissionable" in interfaces
+            ):
                 # Optional: tighten further with name/description if you want
                 # e.g. "HomeAssistant Matter" shows up as friendlyName in the report
                 return True

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -68,10 +68,18 @@ def is_known_ha_bridge(appliance: Optional[dict[str, Any]]) -> bool:
     if appliance.get("manufacturerName") in ("t0bst4r", "Matterbridge"):
         return True
 
-    # If we want to exclude all Matter devices (these can always be added
-    # directly to HA instead of going through AMP), we could test for a
-    # networkInterfaceIdentifier of type "MATTER" or capabilities on the
-    # "Alexa.Matter.NodeOperationalCredentials.FabricManagement" interface.
+    # Identify Matter bridge hubs regardless of manufacturerName
+    if "HUB" in appliance.get("applianceTypes", []):
+        driver_ns = safe_get(appliance, ["driverIdentity", "namespace"], "")
+        driver_id = safe_get(appliance, ["driverIdentity", "identifier"], "")
+        if driver_ns == "AAA" and driver_id == "SonarCloudService":
+            if (
+                _has_interface(appliance, "Alexa.Matter.NodeOperationalCredentials.FabricManagement")
+                or _has_interface(appliance, "Alexa.Commissionable")
+            ):
+                # Optional: tighten further with name/description if you want
+                # e.g. "HomeAssistant Matter" shows up as friendlyName in the report
+                return True
 
     return False
 

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -80,8 +80,6 @@ def is_known_ha_bridge(appliance: Optional[dict[str, Any]]) -> bool:
                 "Alexa.Matter.NodeOperationalCredentials.FabricManagement" in interfaces
                 or "Alexa.Commissionable" in interfaces
             ):
-                # Optional: tighten further with name/description if you want
-                # e.g. "HomeAssistant Matter" shows up as friendlyName in the report
                 return True
 
     return False

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -73,10 +73,9 @@ def is_known_ha_bridge(appliance: Optional[dict[str, Any]]) -> bool:
         driver_ns = safe_get(appliance, ["driverIdentity", "namespace"], "")
         driver_id = safe_get(appliance, ["driverIdentity", "identifier"], "")
         if driver_ns == "AAA" and driver_id == "SonarCloudService":
-            if (
-                _has_interface(appliance, "Alexa.Matter.NodeOperationalCredentials.FabricManagement")
-                or _has_interface(appliance, "Alexa.Commissionable")
-            ):
+            if _has_interface(
+                appliance, "Alexa.Matter.NodeOperationalCredentials.FabricManagement"
+            ) or _has_interface(appliance, "Alexa.Commissionable"):
                 # Optional: tighten further with name/description if you want
                 # e.g. "HomeAssistant Matter" shows up as friendlyName in the report
                 return True


### PR DESCRIPTION
It's been determined that the Home-Assistant-Matter-Hub now exposes most entities with their real HA manufacturer name with fallback to `tobst4r` when unavailable. This leads to AMP replicating those entities back into Home Assistant when `extended_entity_discovery` is enabled.

This addresses that change in behaviour by checking  "Alexa.Matter.NodeOperationalCredentials.FabricManagement" or "Alexa.Commissionable" thereby preventing the loop.

- Fixes #3302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Matter bridge hub detection to more reliably identify compatible bridges and reduce false positives, improving device identification and integration stability across setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->