### PR TITLE
fix: Pass per-account Advanced Debugging flag into entity parsing

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -557,7 +557,7 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                             optional_task_results.pop()
                             entities_to_monitor.clear()
 
-                        alexa_entities = parse_alexa_entities(api_devices)
+                        alexa_entities = parse_alexa_entities(api_devices, debug=login_obj.debug)
                         hass.data[DATA_ALEXAMEDIA]["accounts"][email]["devices"].update(
                             alexa_entities
                         )

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -557,7 +557,9 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                             optional_task_results.pop()
                             entities_to_monitor.clear()
 
-                        alexa_entities = parse_alexa_entities(api_devices, debug=login_obj.debug)
+                        alexa_entities = parse_alexa_entities(
+                            api_devices, debug=login_obj.debug
+                        )
                         hass.data[DATA_ALEXAMEDIA]["accounts"][email]["devices"].update(
                             alexa_entities
                         )

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -558,7 +558,8 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                             entities_to_monitor.clear()
 
                         alexa_entities = parse_alexa_entities(
-                            api_devices, debug=login_obj.debug
+                            api_devices,
+                            debug=hass.data[DATA_ALEXAMEDIA]["accounts"][email]["options"].get(CONF_DEBUG, False)
                         )
                         hass.data[DATA_ALEXAMEDIA]["accounts"][email]["devices"].update(
                             alexa_entities

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -559,7 +559,9 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
 
                         alexa_entities = parse_alexa_entities(
                             api_devices,
-                            debug=hass.data[DATA_ALEXAMEDIA]["accounts"][email]["options"].get(CONF_DEBUG, False)
+                            debug=hass.data[DATA_ALEXAMEDIA]["accounts"][email][
+                                "options"
+                            ].get(CONF_DEBUG, False),
                         )
                         hass.data[DATA_ALEXAMEDIA]["accounts"][email]["devices"].update(
                             alexa_entities


### PR DESCRIPTION
- AlexaLogin.debug is already set from options, but parse_alexa_entities() never received it
- As a result, existing if debug: statements in alexa_entity.py were unreachable
- Wire login_obj.debug through during network discovery parsing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debugging during Alexa device discovery and entity parsing so additional diagnostic information is included when debug is enabled in integration settings. No other functional behavior changes to device handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->