### PR TITLE
docs: clarify intentional permissiveness of Matter bridge applianceId handling in get_device_bridge()

### DIFF
--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -209,8 +209,12 @@ def get_device_bridge(
     if not isinstance(appliance_id, str) or "#" not in appliance_id:
         return None
 
-    # HA Matter Hub bridged endpoints are identified by applianceId prefixes
-    # of the form AAA_SonarCloudService_<bridgeId>#<childId>.
+    # This change intentionally avoids over-validating the applianceId. In Amazon device IDs, # only appears
+    # for bridged devices, and HA Matter Hub bridged endpoints consistently use the
+    # AAA_SonarCloudService_…#… prefix. The previous regex added unnecessary constraints and risked false
+    # negatives; the current logic reflects the actual invariant.
+    # This function is not a general applianceId validator; it only answers “does this look like an HA Matter-
+    # bridged endpoint, and if so, what is its bridge?”
     bridge_id, _sep, _child = appliance_id.partition("#")
 
     if not bridge_id.startswith("AAA_SonarCloudService_"):


### PR DESCRIPTION
This PR revises the inline code comment to make it clearer for maintainers that the previous code change was intentional. In Amazon applianceIds, `#` only appears for bridged endpoints, and HA Matter Hub uses the `AAA_SonarCloudService_…#…` prefix. The previous regex was unnecessarily strict and risked false negatives; this helper only needs to identify the bridge, not validate the full ID format.

Addresses issue #3332 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal code comments for clarity.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->