### PR TITLE
chore(logs): remove misleading 'PROXY DEBUG' prefix

### DIFF
--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -1152,6 +1152,7 @@ class AlexaMediaAuthorizationProxyView(HomeAssistantView):
                     request.url,
                     type(ex).__name__,
                     ex,
+                    exc_info=True,
                 )
                 return web_response.Response(
                     headers={"content-type": "text/html"},


### PR DESCRIPTION
## Summary
- Change session timeout log from WARNING to DEBUG level
- Replace `PROXY DEBUG >>>` prefix with cleaner `Proxy` format
- Simplify exception warning message (removed full traceback from logs)
- Remove unused `traceback` import

## Test plan
- [x] Verify no `PROXY DEBUG` strings remain in code
- [ ] Test proxy login flow works correctly

Fixes #3348
Fixes #3350

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated and clarified proxy-related log messages for more concise, consistent wording.
  * Reduced verbose debug output while preserving important warnings, improving operational readability.
  * Streamlined exception logging to surface essential error details more efficiently for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->