### PR TITLE
fix: type error in string requires string as left operand

### DIFF
--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -8,7 +8,6 @@ https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers
 """
 
 import asyncio
-from collections.abc import Iterable, Mapping
 import functools
 import hashlib
 import logging
@@ -38,32 +37,8 @@ async def add_devices(
     exclude_filter: Optional[list[str]] = None,
 ) -> bool:
     """Add devices using add_devices_callback."""
-
-    def _normalize_filter(value: Any) -> set[str]:
-        """Normalize include/exclude filters to a set[str].
-
-        Some configs/options can yield a single string, None, or other iterables.
-        We only keep non-empty string values to avoid TypeErrors and substring semantics.
-        """
-        if not value:
-            return set()
-        if isinstance(value, str):
-            return {value} if value else set()
-        if isinstance(value, Mapping):
-            # Defensive: if something stored a dict, prefer its values (typically display names)
-            items = value.values()
-        elif isinstance(value, Iterable):
-            items = value
-        else:
-            return set()
-        out: set[str] = set()
-        for item in items:
-            if isinstance(item, str) and item:
-                out.add(item)
-        return out
-
-    include_filter = _normalize_filter(include_filter)
-    exclude_filter = _normalize_filter(exclude_filter)
+    include_filter = include_filter or []
+    exclude_filter = exclude_filter or []
 
     def _device_name(dev: Entity) -> str | None:
         """Best-effort name before entity_id is assigned."""


### PR DESCRIPTION
When checking include/exclude filters, `_dev_name` could be `None` causing the `TypeError: 'in <string>' requires string as left operand, not NoneType` error.

Fixes issues:
- #3354 
- #3358 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Device filtering now accepts multiple input formats for include/exclude filters, improving flexibility when specifying devices.
  * Filters are applied more reliably: only named devices are considered for inclusion/exclusion, and excluded names are skipped.
  * Logs now provide clearer messages when devices are included or skipped due to filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->