### PR TITLE
refactor: Use datetime.fromisoformat()

### DIFF
--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -757,9 +757,7 @@ def is_cap_state_still_acceptable(
         return False
 
     try:
-        time_of_sample = datetime.strptime(
-            formatted_time_of_sample, "%Y-%m-%dT%H:%M:%S%z"
-        )
+        time_of_sample = datetime.fromisoformat(formatted_time_of_sample)
     except ValueError:
         return False
 


### PR DESCRIPTION
The time parsing in `alexa_entity.py` used `strptime` with a fixed format that doesn't handle fractional seconds. Since Python 3.13+ is required (Home Assistant v2025.2.0+) , `datetime.fromisoformat()` can provide better handling of Amazon's timestamp formats.

Addresses issue #3349 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal timestamp parsing to support broader ISO 8601 format compatibility while maintaining consistent error handling and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->