### PR TITLE
fix: increase `get_customer_history_records()` timeout

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -951,7 +951,7 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
 
         if not isinstance(last_called, dict) or not last_called.get("summary"):
             try:
-                async with async_timeout.timeout(10):
+                async with async_timeout.timeout(20):
                     last_called = await AlexaAPI.get_last_device_serial(login_obj)
             except TypeError:
                 _LOGGER.debug(


### PR DESCRIPTION
Some users are occasionally getting:
```
alexaapi.get_customer_history_records((<alexapy.alexalogin.AlexaLogin object at 0x7f1efc196cf0>,), {'max_record_size': 10}): Timeout error occurred accessing AlexaAPI: An exception of type CancelledError occurred. Arguments: ()
```
- Fixes issue #3206 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of last called device detection by extending the timeout duration to better accommodate slower network responses and reduce connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->