### PR TITLE
docs: add `data_description: {}` blocks

### DIFF
--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -68,7 +68,7 @@
           "otp_secret": "52-character Authenticator App Key for Amazon 2SV",
           "public_url": "Public URL shared with external hosted services",
           "queue_delay": "Delay to queue multiple commands together (seconds)",
-          "scan_interval": "Scheduled polling frequency (seconds)",
+          "scan_interval": "Scheduled polling interval (seconds)",
           "should_get_network": "Discover Alexa network"
         },
         "data_description": {

--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -18,8 +18,6 @@
     },
     "step": {
       "user": {
-        "title": "Alexa Media Player - Configuration",
-        "description": "* Required entry",
         "data": {
           "url": "Amazon region domain (e.g., amazon.co.uk)",
           "email": "Email Address",
@@ -34,7 +32,11 @@
           "queue_delay": "Delay to queue multiple commands together (seconds)",
           "should_get_network": "Discover Alexa network",
           "extended_entity_discovery": "Include additional sensors, switches and lights",
-          "debug": "Advanced debugging"
+          "debug": "Advanced debug"
+        },
+        "data_description": {
+          "otp_secret": "Example: 35T5 LQSY I5IO 3EFQ LGAJ I6YB JWBY JJPR PYT7 XPPW IDAK SQBJ CVXA",
+          "debug": "Enables very verbose, trace-level logging for advanced troubleshooting.\nNot recommended for normal operation due to increased log volume.\nEnsure logger levels are set to DEBUG for full output."
         }
       },
       "proxy_warning": {
@@ -66,7 +68,11 @@
           "queue_delay": "Delay to queue multiple commands together (seconds)",
           "should_get_network": "Discover Alexa network",
           "extended_entity_discovery": "Include additional sensors, switches and lights",
-          "debug": "Advanced debugging"
+          "debug": "Advanced debug"
+        },
+        "data_description": {
+          "otp_secret": "Example: 35T5 LQSY I5IO 3EFQ LGAJ I6YB JWBY JJPR PYT7 XPPW IDAK SQBJ CVXA",
+          "debug": "Enables very verbose, trace-level logging for advanced troubleshooting.\nNot recommended for normal operation due to increased log volume.\nEnsure logger levels are set to DEBUG for full output."
         }
       }
     }

--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -19,24 +19,24 @@
     "step": {
       "user": {
         "data": {
-          "url": "Amazon region domain (e.g., amazon.co.uk)",
+          "debug": "Advanced debug",
           "email": "Email Address",
-          "password": "Password",
-          "securitycode": "One-time password (OTP)",
-          "otp_secret": "52-character Authenticator App Key for Amazon 2SV",
-          "hass_url": "Local network URL to access Home Assistant",
-          "public_url": "Public URL shared with external hosted services",
-          "include_devices": "Only include these devices (comma separated)",
           "exclude_devices": "or Exclude these devices from all (comma separated)",
-          "scan_interval": "Scheduled polling interval (seconds)",
-          "queue_delay": "Delay to queue multiple commands together (seconds)",
-          "should_get_network": "Discover Alexa network",
           "extended_entity_discovery": "Include additional sensors, switches and lights",
-          "debug": "Advanced debug"
+          "hass_url": "Local network URL to access Home Assistant",
+          "include_devices": "Only include these devices (comma separated)",
+          "otp_secret": "52-character Authenticator App Key for Amazon 2SV",
+          "password": "Password",
+          "public_url": "Public URL shared with external hosted services",
+          "queue_delay": "Delay to queue multiple commands together (seconds)",
+          "scan_interval": "Scheduled polling interval (seconds)",
+          "securitycode": "One-time password (OTP)",
+          "should_get_network": "Discover Alexa network",
+          "url": "Amazon region domain (e.g., amazon.co.uk)"
         },
         "data_description": {
-          "otp_secret": "Example: 35T5 LQSY I5IO 3EFQ LGAJ I6YB JWBY JJPR PYT7 XPPW IDAK SQBJ CVXA",
-          "debug": "Enables very verbose, trace-level logging for advanced troubleshooting.\nNot recommended for normal operation due to increased log volume.\nEnsure logger levels are set to DEBUG for full output."
+          "debug": "Enables very verbose, trace-level logging for advanced troubleshooting.\nNot recommended for normal operation due to increased log volume.\nEnsure logger levels are set to DEBUG for full output.",
+          "otp_secret": "Example: 35T5 LQSY I5IO 3EFQ LGAJ I6YB JWBY JJPR PYT7 XPPW IDAK SQBJ CVXA"
         }
       },
       "proxy_warning": {
@@ -61,18 +61,19 @@
         "title": "Alexa Media Player - Reconfiguration",
         "description": "* Required entry",
         "data": {
-          "public_url": "Public URL shared with external hosted services",
-          "include_devices": "Only include these devices (comma separated)",
+          "debug": "Advanced debug",
           "exclude_devices": "or Exclude these devices from all (comma separated)",
-          "scan_interval": "Scheduled polling frequency (seconds)",
-          "queue_delay": "Delay to queue multiple commands together (seconds)",
-          "should_get_network": "Discover Alexa network",
           "extended_entity_discovery": "Include additional sensors, switches and lights",
-          "debug": "Advanced debug"
+          "include_devices": "Only include these devices (comma separated)",
+          "otp_secret": "52-character Authenticator App Key for Amazon 2SV",
+          "public_url": "Public URL shared with external hosted services",
+          "queue_delay": "Delay to queue multiple commands together (seconds)",
+          "scan_interval": "Scheduled polling frequency (seconds)",
+          "should_get_network": "Discover Alexa network"
         },
         "data_description": {
-          "otp_secret": "Example: 35T5 LQSY I5IO 3EFQ LGAJ I6YB JWBY JJPR PYT7 XPPW IDAK SQBJ CVXA",
-          "debug": "Enables very verbose, trace-level logging for advanced troubleshooting.\nNot recommended for normal operation due to increased log volume.\nEnsure logger levels are set to DEBUG for full output."
+          "debug": "Enables very verbose, trace-level logging for advanced troubleshooting.\nNot recommended for normal operation due to increased log volume.\nEnsure logger levels are set to DEBUG for full output.",
+          "otp_secret": "Example: 35T5 LQSY I5IO 3EFQ LGAJ I6YB JWBY JJPR PYT7 XPPW IDAK SQBJ CVXA"
         }
       }
     }


### PR DESCRIPTION
Add extended data description blocks:
```
        "data_description": {
          "otp_secret": "Example: 35T5 LQSY I5IO 3EFQ LGAJ I6YB JWBY JJPR PYT7 XPPW IDAK SQBJ CVXA",
          "debug": "Enables very verbose, trace-level logging for advanced troubleshooting.\nNot recommended for normal operation due to increased log volume.\nEnsure logger levels are set to DEBUG for full output."
        }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified and reorganized setup, proxy warning, and options text for clearer presentation.
  * Made OTP/secret descriptions and an advanced debug option visible in setup and options flows.
  * Exposed several additional configuration fields in the UI (device inclusion/exclusion, public URL, scan interval, queue delay, security/2FA controls) and adjusted their order for better discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->