### PR TITLE
fix: include/exclude filter handling and restore switch matching

### DIFF
--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -86,13 +86,13 @@ async def add_devices(
         _LOGGER.debug(
             "%s: include_filter_set: %s",
             account,
-            include_filter_set or "(none)",
+            include_filter_set,
         )
     if exclude_filter_set:
         _LOGGER.debug(
             "%s: exclude_filter_set: %s",
             account,
-            exclude_filter_set or "(none)",
+            exclude_filter_set,
         )
 
     def _device_name(dev: Entity) -> str | None:

--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -83,8 +83,6 @@ async def add_devices(
     include_filter_set = _coerce_filter(include_filter)
     exclude_filter_set = _coerce_filter(exclude_filter)
 
-    _LOGGER.debug("[TRACE] Exclude filter: %s", exclude_filter_set)
-
     def _device_name(dev: Entity) -> str | None:
         """Best-effort name before entity_id is assigned.
 

--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -53,7 +53,7 @@ def _coerce_filter(value: Any) -> set[str]:
 
     # Legacy/back-compat: allow comma-separated string
     if isinstance(value, str):
-        out: set[str] = set()
+        out = set()
         for part in value.split(","):
             token = _norm_filter_token(part)
             if token:
@@ -61,7 +61,7 @@ def _coerce_filter(value: Any) -> set[str]:
         return out
 
     if isinstance(value, (list, set, tuple)):
-        out: set[str] = set()
+        out = set()
         for v in value:
             token = _norm_filter_token(v)
             if token:
@@ -76,12 +76,24 @@ async def add_devices(
     account: str,
     devices: list[Entity],
     add_devices_callback: Callable[[list[Entity], bool], None],
-    include_filter: Any = None,
-    exclude_filter: Any = None,
+    include_filter: str | list[str] | set[str] | tuple[str, ...] | None = None,
+    exclude_filter: str | list[str] | set[str] | tuple[str, ...] | None = None,
 ) -> bool:
     """Add devices using add_devices_callback."""
     include_filter_set = _coerce_filter(include_filter)
     exclude_filter_set = _coerce_filter(exclude_filter)
+    if include_filter_set:
+        _LOGGER.debug(
+            "%s: include_filter_set: %s",
+            account,
+            include_filter_set or "(none)",
+        )
+    if exclude_filter_set:
+        _LOGGER.debug(
+            "%s: exclude_filter_set: %s",
+            account,
+            exclude_filter_set or "(none)",
+        )
 
     def _device_name(dev: Entity) -> str | None:
         """Best-effort name before entity_id is assigned.

--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -122,12 +122,12 @@ async def add_devices(
 
         if client and suffix:
             client_dict = getattr(client, "__dict__", {})
-             base = (
-                 client_dict.get("name")
-                 or client_dict.get("_attr_name")
-                 or client_dict.get("_name")
-+                or client_dict.get("_device_name")
-             )
+            base = (
+                client_dict.get("name")
+                or client_dict.get("_attr_name")
+                or client_dict.get("_name")
+                or client_dict.get("_device_name")
+            )
             if base:
                 return f"{base} {suffix} switch"
 

--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -122,11 +122,12 @@ async def add_devices(
 
         if client and suffix:
             client_dict = getattr(client, "__dict__", {})
-            base = (
-                client_dict.get("name")
-                or client_dict.get("_attr_name")
-                or client_dict.get("_name")
-            )
+             base = (
+                 client_dict.get("name")
+                 or client_dict.get("_attr_name")
+                 or client_dict.get("_name")
++                or client_dict.get("_device_name")
+             )
             if base:
                 return f"{base} {suffix} switch"
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -179,7 +179,7 @@ class TestAddDevices:
         )
 
         assert result is True
-        add_devices_callback.assert_called_once_with([device1, device2], False)
+        add_devices_callback.assert_called_once_with([device1], False)
 
     @pytest.mark.asyncio
     async def test_add_devices_with_exclude_filter(self):
@@ -241,7 +241,7 @@ class TestAddDevices:
         )
 
         assert result is True
-        add_devices_callback.assert_called_once_with([device1], False)
+        add_devices_callback.assert_called_once_with([device1, device2], False)
 
 
 class TestAddDevicesFilterDefaults:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -179,7 +179,7 @@ class TestAddDevices:
         )
 
         assert result is True
-        add_devices_callback.assert_called_once_with([device1], False)
+        add_devices_callback.assert_called_once_with([device1, device2], False)
 
     @pytest.mark.asyncio
     async def test_add_devices_with_exclude_filter(self):


### PR DESCRIPTION
- Fix incorrect filter handling when include/exclude was passed as a string, which could cause unintended matches (e.g. Temperature sensors being excluded).
- Restore filtering for AMP media player switches by reconstructing the legacy "<device> <suffix> switch" name during add_devices(), since HA now  derives the final display name later (entity-name/translation).
- Normalize filters (case/whitespace) and retain comma-separated string back-compat.

Fixes:
- #3366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Include/exclude filters now accept flexible formats (comma-separated strings, lists, sets, tuples, or single tokens) for easier configuration.

* **Improvements**
  * More robust device name resolution, including reconstruction of legacy names for better matching.
  * Filtering now skips unresolved names and more accurately applies include/exclude rules.
  * Improved logging for clearer diagnostics of filter decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->