### PR TITLE
feat: added support for Denon Home 150 and 250 and renamed Fire TV Stick 4K Max

### DIFF
--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -322,7 +322,7 @@ MODEL_IDS = {
     "A3CY98NH016S5F": "Facebook Portal Mini",
     "A3D4YURNTARP5K": "Facebook Portal TV",
     "A3EH2E0YZ30OD6": "Echo Spot (Gen2)",
-    "A3EVMLQTU6WL1W": "Fire TV (GenX)",
+    "A3EVMLQTU6WL1W": "Fire TV Stick 4K Max (Gen1)",
     "A3F1S88NTZZXS9": "Dash Wand",
     "A3FX4UWTP28V1P": "Echo (Gen3)",
     "A3GFRGUNIGG1I5": "Samsung TV QN50Q60CAGXZD",


### PR DESCRIPTION
Inspired by #3378 I added two of my Denon devices. 

One limitation: I dont have a Denon Home 350, so don't know what the identifier of that one is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Denon Home 150 and Denon Home 250 speakers—discoverable, status shown, and controllable from the app.
* **Other**
  * Updated device naming for a Fire TV entry to "Fire TV Stick 4K Max (Gen1)" for clearer identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->