### PR TITLE
refactor: avoid set name collision

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -707,7 +707,7 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                         metrics.record_api_call("initial_fetch", fetch_time)
                         # Cache the devices for faster next boot (only freshly fetched)
                         if not _used_cached_devices:
-                            metrics.api_cache.set(
+                            metrics.api_cache.cache_set(
                                 f"{cache_key_prefix}_devices", devices
                             )
 

--- a/custom_components/alexa_media/metrics.py
+++ b/custom_components/alexa_media/metrics.py
@@ -85,7 +85,7 @@ class DataCache:
         self._hits += 1
         return value
 
-    def set(self, key: str, value: Any) -> None:
+    def cache_set(self, key: str, value: Any) -> None:
         """Store value in cache.
 
         Note: Stores a direct reference (not a copy) for performance.


### PR DESCRIPTION
Issue identified during review of PR #3390
Reported by: @coderabbitai
Requested by: @alandtse

Description:
In custom_components/alexa_media/metrics.py around lines 46-122, the DataCache.set method name shadows Python's built-in set type.

Current implementation:

def set(self, key: str, value: Any) -> None:
Suggested improvement:
Rename to a clearer name that doesn't shadow built-ins, such as:

cache_set
store
put
Impact:
Nitpick - No runtime problem since it's a method, but better practice to avoid shadowing built-ins for code clarity.

Reference:

PR: chore: release 2026-02-21 #3390
File: custom_components/alexa_media/metrics.py:46-122

Fixes: #3394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed an internal caching API for consistency; no change to behavior or user-facing functionality.
  * Startup data handling remains unchanged; users should notice no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->