### PR TITLE
docs: clarify cached device mutation contract

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -596,6 +596,8 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
 
         if cached_devices and not new_devices:
             _LOGGER.debug("%s: Using cached devices data", hide_email(email))
+            # NOTE: DataCache returns direct references. We intentionally enrich device dicts
+            # in-place each refresh cycle (bluetooth_state/locale/dnd/etc.).
             devices = cached_devices
             _used_cached_devices = True
             # Still need fresh bluetooth, preferences, and DND

--- a/custom_components/alexa_media/metrics.py
+++ b/custom_components/alexa_media/metrics.py
@@ -89,7 +89,8 @@ class DataCache:
         """Store value in cache.
 
         Note: Stores a direct reference (not a copy) for performance.
-        Callers should not mutate cached values.
+        Callers should treat cached values as read-only unless they *own* the data
+        lifecycle and intentionally enrich it in-place.
 
         Args:
             key: Cache key

--- a/custom_components/alexa_media/metrics.py
+++ b/custom_components/alexa_media/metrics.py
@@ -89,8 +89,9 @@ class DataCache:
         """Store value in cache.
 
         Note: Stores a direct reference (not a copy) for performance.
-        Callers should treat cached values as read-only unless they *own* the data
-        lifecycle and intentionally enrich it in-place.
+        Callers should treat cached values as read-only unless the caller created
+        the cached object, is solely responsible for all mutations, and intentionally
+        enriches it in-place (e.g., the device-dict refresh in async_update_data).
 
         Args:
             key: Cache key


### PR DESCRIPTION
Issue identified during review of PR https://github.com/alandtse/alexa_media_player/pull/3390
Reported by: https://github.com/coderabbitai
Requested by: @alandtse

Description:
In custom_components/alexa_media/__init__.py around lines 588-712, the DataCache documentation states it "stores a direct reference (not a copy)" and warns callers not to mutate. However, lines 919-946 mutate individual device dicts in-place (adding bluetooth_state, locale, dnd, etc.), which modifies the cached reference.

Current behavior:
The code intentionally mutates cached references, which contradicts the cache's documented contract.

Suggested improvements:
Either:

Deep-copy on cache retrieval: devices = copy.deepcopy(cached_devices)
Add a clear comment acknowledging that mutation is intentional in this specific case
Impact:
Nitpick - Works correctly in practice because mutations overwrite with fresh data each cycle, but violates documented contract.

Reference:

PR: https://github.com/alandtse/alexa_media_player/pull/3390
File: custom_components/alexa_media/init.py:588-712

Fixes: #3395 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how cached device data is handled and guidance on treating cached values as read-only unless explicitly owned and mutated.

* **Chores**
  * Added explanatory comments noting that device records are enriched in-place during refresh cycles.

Note: No user-facing changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->