### PR TITLE
fix: bump alexapy to v1.29.18

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,7 @@ Always reference these instructions first and fallback to search or bash command
   - `poetry install` -- takes 2-3 minutes on first run. NEVER CANCEL. Set timeout to 10+ minutes.
   - If Poetry fails due to version conflicts: `poetry lock --no-update` first, then `poetry install`
 - **FALLBACK**: Install core dependencies manually if Poetry fails:
-  - `pip3 install alexapy==1.29.17 packaging wrapt async_timeout aiohttp`
+  - `pip3 install alexapy==1.29.18 packaging wrapt async_timeout aiohttp`
   - This allows basic functionality but may miss dev dependencies
 
 ### Linting and Code Quality (ALWAYS run before committing)
@@ -109,7 +109,7 @@ cat custom_components/alexa_media/manifest.json  # HA integration manifest
 
 ### Dependency Management
 
-- **Core dependencies**: alexapy==1.29.17, aiohttp>=3.8.1, packaging>=20.3, wrapt>=1.12.1
+- **Core dependencies**: alexapy==1.29.18, aiohttp>=3.8.1, packaging>=20.3, wrapt>=1.12.1
 - **Dev dependencies**: homeassistant>=2025.2.0, pytest-homeassistant-custom-component>=0.13.107
 - Add new dependencies to `pyproject.toml` then run `poetry lock`
 - **NEVER CANCEL**: `poetry lock` can take 60+ seconds. Set timeout to 10+ minutes.

--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/alandtse/alexa_media_player/issues",
   "loggers": ["alexapy", "authcaptureproxy"],
   "requirements": [
-    "alexapy==1.29.17",
+    "alexapy==1.29.18",
     "packaging>=20.3",
     "wrapt>=1.14.0",
     "dictor>=0.1.12,<0.2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -283,14 +283,14 @@ tzdata = ">=2024.1"
 
 [[package]]
 name = "alexapy"
-version = "1.29.17"
+version = "1.29.18"
 description = "Python API to control Amazon Echo Devices Programmatically."
 optional = false
 python-versions = "<4,>=3.11"
 groups = ["main"]
 files = [
-    {file = "alexapy-1.29.17-py3-none-any.whl", hash = "sha256:0e544c2bc48f5da3c81805f90a035cbde21344385296b5fda2869cd5b470f3d3"},
-    {file = "alexapy-1.29.17.tar.gz", hash = "sha256:f601830eae1a24d6bc8d97bba471f3c0ccc0262bcda7af04bd2d987280f36ce4"},
+    {file = "alexapy-1.29.18-py3-none-any.whl", hash = "sha256:36994c297008ee207a494efb7c819d540efbafdc88be84c699bf9f6403a4c0b9"},
+    {file = "alexapy-1.29.18.tar.gz", hash = "sha256:b7c7d3823f2ae25c2d8bf3773a4c459e8e07252857850e7202671b755312ea35"},
 ]
 
 [package.dependencies]
@@ -5946,4 +5946,4 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "dc582ca2f7b51f41f051b65e9e8c37b9f74252692d8fd9b471c2acea31b25008"
+content-hash = "bb2dd2a722a0c3687945d727ed00c39247eb8f87875594db5a8a57a1a8818f18"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.13,<4.0"
-alexapy = "1.29.17"
+alexapy = "1.29.18"
 aiohttp = ">=3.8.1"
 packaging = ">=20.3"
 wrapt = ">=1.12.1"


### PR DESCRIPTION
- [x] Update alexapy version in `.github/copilot-instructions.md` (documentation)
- [x] Update alexapy version in `custom_components/alexa_media/manifest.json`
- [x] Update alexapy version in `pyproject.toml`
- [x] Update `poetry.lock`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated alexapy dependency to version 1.29.18 across configuration files for enhanced stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->