### PR TITLE
fix: bump alexapy to 1.29.20

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,7 @@ Always reference these instructions first and fallback to search or bash command
   - `poetry install` -- takes 2-3 minutes on first run. NEVER CANCEL. Set timeout to 10+ minutes.
   - If Poetry fails due to version conflicts: `poetry lock --no-update` first, then `poetry install`
 - **FALLBACK**: Install core dependencies manually if Poetry fails:
-  - `pip3 install alexapy==1.29.19 packaging wrapt async_timeout aiohttp`
+  - `pip3 install alexapy==1.29.20 packaging wrapt async_timeout aiohttp`
   - This allows basic functionality but may miss dev dependencies
 
 ### Linting and Code Quality (ALWAYS run before committing)
@@ -109,7 +109,7 @@ cat custom_components/alexa_media/manifest.json  # HA integration manifest
 
 ### Dependency Management
 
-- **Core dependencies**: alexapy==1.29.19, aiohttp>=3.8.1, packaging>=20.3, wrapt>=1.12.1
+- **Core dependencies**: alexapy==1.29.20, aiohttp>=3.8.1, packaging>=20.3, wrapt>=1.12.1
 - **Dev dependencies**: homeassistant>=2025.2.0, pytest-homeassistant-custom-component>=0.13.107
 - Add new dependencies to `pyproject.toml` then run `poetry lock`
 - **NEVER CANCEL**: `poetry lock` can take 60+ seconds. Set timeout to 10+ minutes.

--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/alandtse/alexa_media_player/issues",
   "loggers": ["alexapy", "authcaptureproxy"],
   "requirements": [
-    "alexapy==1.29.19",
+    "alexapy==1.29.20",
     "packaging>=20.3",
     "wrapt>=1.14.0",
     "dictor>=0.1.12,<0.2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -283,14 +283,14 @@ tzdata = ">=2024.1"
 
 [[package]]
 name = "alexapy"
-version = "1.29.19"
+version = "1.29.20"
 description = "Python API to control Amazon Echo Devices Programmatically."
 optional = false
 python-versions = "<4,>=3.11"
 groups = ["main"]
 files = [
-    {file = "alexapy-1.29.19-py3-none-any.whl", hash = "sha256:f472e1297b9c59b3c7059faa73cd56b7f15c9f93238dede41f06d45a2836c96a"},
-    {file = "alexapy-1.29.19.tar.gz", hash = "sha256:bfd237f92ad2312db1a1d9acfc2afc2b26c9320e1675ce337c219da0bab91c93"},
+    {file = "alexapy-1.29.20-py3-none-any.whl", hash = "sha256:1ee06b94037eecdde6e0f892bc5a3cf2038a7601d64bd213733deeca07ff074a"},
+    {file = "alexapy-1.29.20.tar.gz", hash = "sha256:728df8a2b1c71941f7fa275e1166158af37d3a16f5ae235e9187a14702de40dd"},
 ]
 
 [package.dependencies]
@@ -5946,4 +5946,4 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "9e23993559687cfa4d97c5a1ba351a9873c1b87a166048d78034bd7a1b274ff9"
+content-hash = "c08ffdcab165805f9505bf5d10024338ca13123df3afc193e42d6c14f9cad676"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.13,<4.0"
-alexapy = "1.29.19"
+alexapy = "1.29.20"
 aiohttp = ">=3.8.1"
 packaging = ">=20.3"
 wrapt = ">=1.12.1"


### PR DESCRIPTION
- [x] Update alexapy version in `.github/copilot-instructions.md` (documentation)
- [x] Update alexapy version in `custom_components/alexa_media/manifest.json`
- [x] Update alexapy version in `pyproject.toml`
- [x] Update `poetry.lock`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->