### PR TITLE
fix: handle TypeError from aiohttp None in last_called probe

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(git show HEAD -- \"custom_components/alexa_media/__init__.py\")"
-    ]
-  }
-}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "permissions": {
     "allow": [
-      "Bash(git -C \"c:/Users/aawar/OneDrive - Microsoft/Documents/GitHub/alexa_media_player\" show HEAD -- \"custom_components/alexa_media/__init__.py\")"
+      "Bash(git show HEAD -- \"custom_components/alexa_media/__init__.py\")"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git -C \"c:/Users/aawar/OneDrive - Microsoft/Documents/GitHub/alexa_media_player\" show HEAD -- \"custom_components/alexa_media/__init__.py\")"
+    ]
+  }
+}

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -1587,14 +1587,40 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                                     LAST_CALLED_ITEMS, len(queue_snapshot) + 2
                                 )
 
+                            try:
                                 records = await AlexaAPI.get_customer_history_records(
                                     login_live,
                                     start_time=start_time,
                                     end_time=end_time,
                                     max_record_size=max_record_size,
                                 )
+                            except TypeError as exc:
+                                # Known alexapy/aiohttp edge case: None header key, etc.
+                                account_live["last_called_probe_next_allowed"] = (
+                                    time.monotonic() + LAST_CALLED_CONN_BACKOFF_S
+                                )
+                                _LOGGER.warning(
+                                    "%s: last_called probe API TypeError (%s): %s",
+                                    hide_email(email),
+                                    trigger_cmd,
+                                    exc,
+                                    exc_info=True,
+                                )
+                                # NOTE:
+                                # We intentionally re-arm the probe (set event + backoff) on this TypeError
+                                # because this path is typically caused by transient alexapy/aiohttp issues
+                                # (e.g., None header key). Unlike Login/Connection errors, we retry quickly
+                                # to avoid losing last_called updates triggered by push events.
+                                skip_debounce = True
+                                account_live["last_called_probe_event"].set()
+                                break
 
                             if records is None:
+                                _LOGGER.warning(
+                                    "%s: last_called probe API returned None (%s)",
+                                    hide_email(email),
+                                    trigger_cmd,
+                                )
                                 records = []
 
                             # 🔎 DEBUG: inspect raw history result
@@ -1684,19 +1710,6 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                                 trigger_cmd,
                                 exc,
                             )
-                            break
-                        except TypeError as exc:
-                            account_live["last_called_probe_next_allowed"] = (
-                                time.monotonic() + LAST_CALLED_CONN_BACKOFF_S
-                            )
-                            _LOGGER.debug(
-                                "%s: last_called probe type error (%s): %s",
-                                hide_email(email),
-                                trigger_cmd,
-                                exc,
-                            )
-                            skip_debounce = True
-                            account_live["last_called_probe_event"].set()
                             break
 
                         existing_serials_local = set(

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -1685,6 +1685,17 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                                 exc,
                             )
                             break
+                        except TypeError as exc:
+                            account_live["last_called_probe_next_allowed"] = (
+                                time.monotonic() + LAST_CALLED_CONN_BACKOFF_S
+                            )
+                            _LOGGER.debug(
+                                "%s: last_called probe type error (%s): %s",
+                                hide_email(email),
+                                trigger_cmd,
+                                exc,
+                            )
+                            break
 
                         existing_serials_local = set(
                             _existing_serials(hass, login_live)

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -1695,6 +1695,8 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                                 trigger_cmd,
                                 exc,
                             )
+                            skip_debounce = True
+                            account_live["last_called_probe_event"].set()
                             break
 
                         existing_serials_local = set(


### PR DESCRIPTION
```
                             break
+                        except TypeError as exc:
+                            account_live["last_called_probe_next_allowed"] = (
+                                time.monotonic() + LAST_CALLED_CONN_BACKOFF_S
+                            )
+                            _LOGGER.debug(
+                                "%s: last_called probe type error (%s): %s",
+                                hide_email(email),
+                                trigger_cmd,
+                                exc,
+                            )
+                            break

                         existing_serials_local = set(

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of intermittent probe errors to avoid interruptions.
  * Probe worker now schedules retries using the existing connection backoff, restoring normal probing sooner.
  * Added clearer debug logging to help trace probe triggers and exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->