### PR TITLE
fix(notify): expand group entities target resolution

### DIFF
--- a/custom_components/alexa_media/notify.py
+++ b/custom_components/alexa_media/notify.py
@@ -240,11 +240,10 @@ class AlexaNotificationService(BaseNotificationService):
         # swallowed — it never successfully expanded anything.
         expanded_targets = []
         for target in processed_targets:
-            state = self.hass.states.get(target)
             if (
-                state is not None
-                and isinstance(target, str)
+                isinstance(target, str)
                 and target.startswith("media_player.")
+                and (state := self.hass.states.get(target)) is not None
                 and "entity_id" in state.attributes
             ):
                 # This is a media_player group — expand to its member entity IDs
@@ -252,7 +251,16 @@ class AlexaNotificationService(BaseNotificationService):
                 _LOGGER.debug(
                     "Expanding media_player group %s to members: %s", target, members
                 )
-                expanded_targets.extend(members)
+                if isinstance(members, (list, tuple)):
+                    expanded_targets.extend(members)
+                else:
+                    _LOGGER.debug(
+                        "Skipping expansion for media_player group %s: "
+                        "entity_id attribute is not a list (%s), using group as-is",
+                        target,
+                        type(members).__name__,
+                    )
+                    expanded_targets.append(target)
             else:
                 expanded_targets.append(target)
         processed_targets = expanded_targets

--- a/custom_components/alexa_media/notify.py
+++ b/custom_components/alexa_media/notify.py
@@ -225,11 +225,38 @@ class AlexaNotificationService(BaseNotificationService):
                         map(lambda x: x.strip(), target.split(","))
                     )
                     _LOGGER.debug("Processed Target by string: %s", processed_targets)
+        # Expand media_player group entities into their member entity IDs before
+        # passing to convert(). The convert() method only resolves alexa-specific
+        # identifiers (entity_id, name, serial); it has no knowledge of HA groups.
+        # We expand here — before convert() — where targets are still plain strings.
+        #
+        # Scope: media_player groups only (identified by a media_player.* entity_id
+        # whose state contains an "entity_id" attribute listing member entities).
+        # Areas, floors, and generic group.* entities are intentionally out of scope.
+        #
+        # Note: The expand_entity_ids() call that previously appeared after convert()
+        # has been removed. It operated on already-converted alexa objects (not entity
+        # ID strings), causing it to throw ValueError on every call, which was silently
+        # swallowed — it never successfully expanded anything.
+        expanded_targets = []
+        for target in processed_targets:
+            state = self.hass.states.get(target)
+            if (
+                state is not None
+                and isinstance(target, str)
+                and target.startswith("media_player.")
+                and "entity_id" in state.attributes
+            ):
+                # This is a media_player group — expand to its member entity IDs
+                members = state.attributes["entity_id"]
+                _LOGGER.debug(
+                    "Expanding media_player group %s to members: %s", target, members
+                )
+                expanded_targets.extend(members)
+            else:
+                expanded_targets.append(target)
+        processed_targets = expanded_targets
         entities = self.convert(processed_targets, type_="entities")
-        try:
-            entities.extend(expand_entity_ids(self.hass, entities))
-        except ValueError:
-            _LOGGER.debug("Invalid Home Assistant entity in %s", entities)
         tasks = []
         for account, account_dict in self.hass.data[DATA_ALEXAMEDIA][
             "accounts"


### PR DESCRIPTION
Summary

When a media_player group entity is passed as a target to notify.alexa_media, the announcement silently does nothing. This is because target resolution (convert()) only matches against known Alexa entity identifiers — it has no mechanism to expand HA group entities into their members before matching.

Changes

In async_send_message, before targets are passed to convert(), check if any target string refers to a media_player group entity (identified by the presence of an entity_id attribute in its state). If so, replace it with its member entity IDs. Non-group targets are unchanged.

The existing expand_entity_ids call after convert() has also been removed — it operated on already-converted objects (not strings), causing inconsistent behavior and silent failures.

Behavior

• target: media_player.my_echo_group → expands to all member Echo entities → announcement plays on all of them
• target: media_player.echo_office → unchanged, works as before
• Any non-group target → unchanged, falls through as before

Testing

Tested manually against a local HA instance with a media_player group containing multiple Echo devices. Announcement plays on all members when the group entity is used as the target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications targeting media player groups now correctly expand group members before delivery, resolving cases where some devices were previously skipped or not reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->