### PR TITLE
fix: `include_devices` not including derived entities

### DIFF
--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -109,6 +109,29 @@ async def add_devices(
             or getattr(dev, "_name", None)
             or getattr(dev, "_device_name", None)
             or getattr(dev, "_friendly_name", None)
+        )
+        if name:
+            return name
+
+        # Only attempt switch reconstruction if attributes were explicitly defined
+        # (avoids MagicMock auto-attribute trap in tests)
+        dev_dict = getattr(dev, "__dict__", {})
+
+        client = dev_dict.get("_client")
+        suffix = dev_dict.get("_unique_id_suffix")
+
+        if client and suffix:
+            client_dict = getattr(client, "__dict__", {})
+            base = (
+                client_dict.get("name")
+                or client_dict.get("_attr_name")
+                or client_dict.get("_name")
+                or client_dict.get("_device_name")
+            )
+            if base:
+                return f"{base} {suffix} switch"
+
+        return None
 
     def _device_base_name(dev: Entity) -> str | None:
         """Return the parent/base device name for derived AMP entities."""
@@ -177,8 +200,9 @@ async def add_devices(
             # INCLUDE MODE:
             # include exact entity matches OR children of an included parent device
             if include_mode:
-                if (dev_name and dev_name in include_set) or (
-                    base_name and base_name in include_set
+                if (
+                    (dev_name and dev_name in include_set)
+                    or (base_name and base_name in include_set)
                 ):
                     selected.append(dev)
                 else:

--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -95,6 +95,21 @@ async def add_devices(
             exclude_filter_set,
         )
 
+    def _device_name(dev: Entity) -> str | None:
+        """Best-effort name before entity_id is assigned.
+
+        For AMP switches, reconstruct the legacy "<device> <suffix> switch"
+        name only if those attributes were explicitly set.
+        """
+
+        # First prefer explicitly set name attributes (works for tests + most entities)
+        name = (
+            getattr(dev, "name", None)
+            or getattr(dev, "_attr_name", None)
+            or getattr(dev, "_name", None)
+            or getattr(dev, "_device_name", None)
+            or getattr(dev, "_friendly_name", None)
+
     def _device_base_name(dev: Entity) -> str | None:
         """Return the parent/base device name for derived AMP entities."""
         # Prefer __dict__ first to avoid MagicMock auto-attribute traps in tests,
@@ -122,35 +137,6 @@ async def add_devices(
             return str(base)
 
         return None
-
-    def _device_base_name(dev: Entity) -> str | None:
-        """Return the parent/base device name for derived AMP entities."""
-        client = _explicit_attr(dev, "_client")
-        if client is None:
-            client = getattr(dev, "_client", None)
-
-        if not client or isinstance(client, Mock):
-            return None
-
-        base = (
-            _explicit_attr(client, "name")
-            or _explicit_attr(client, "_attr_name")
-            or _explicit_attr(client, "_name")
-            or _explicit_attr(client, "_device_name")
-        )
-
-        if base is None:
-            base = (
-                getattr(client, "name", None)
-                or getattr(client, "_attr_name", None)
-                or getattr(client, "_name", None)
-                or getattr(client, "_device_name", None)
-            )
-
-        if not base or isinstance(base, Mock):
-            return None
-
-        return str(base)
 
     def _device_label(dev: Entity) -> str:
         """Return a compact, stable identifier for logging."""

--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -192,9 +192,8 @@ async def add_devices(
             # INCLUDE MODE:
             # include exact entity matches OR children of an included parent device
             if include_mode:
-                if (
-                    (dev_name and dev_name in include_set)
-                    or (base_name and base_name in include_set)
+                if (dev_name and dev_name in include_set) or (
+                    base_name and base_name in include_set
                 ):
                     selected.append(dev)
                 else:

--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -191,9 +191,8 @@ async def add_devices(
             # INCLUDE MODE:
             # include exact entity matches OR children of an included parent device
             if include_mode:
-                if (
-                    (dev_name and dev_name in include_set)
-                    or (base_name and base_name in include_set)
+                if (dev_name and dev_name in include_set) or (
+                    base_name and base_name in include_set
                 ):
                     selected.append(dev)
                 else:

--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -200,18 +200,32 @@ async def add_devices(
             # INCLUDE MODE:
             # include exact entity matches OR children of an included parent device
             if include_mode:
-                if (dev_name and dev_name in include_set) or (
-                    base_name and base_name in include_set
-                ):
+                if dev_name and dev_name in include_set:
                     selected.append(dev)
-                else:
+                elif base_name and base_name in include_set:
                     _LOGGER.debug(
-                        "%s: Not including device: %s (match key=%r, base=%r)",
+                        "%s: Including device via parent match: %s (match key=%r, base=%r)",
                         account,
                         _device_label(dev),
                         dev_name,
                         base_name,
                     )
+                    selected.append(dev)
+                else:
+                    if not dev_name:
+                        _LOGGER.debug(
+                            "%s: Not including device (no name yet): %s",
+                            account,
+                            _device_label(dev),
+                        )
+                    else:
+                        _LOGGER.debug(
+                            "%s: Not including device: %s (match key=%r, base=%r)",
+                            account,
+                            _device_label(dev),
+                            dev_name,
+                            base_name,
+                        )
                 continue
 
             # EXCLUDE MODE:

--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -200,9 +200,8 @@ async def add_devices(
             # INCLUDE MODE:
             # include exact entity matches OR children of an included parent device
             if include_mode:
-                if (
-                    (dev_name and dev_name in include_set)
-                    or (base_name and base_name in include_set)
+                if (dev_name and dev_name in include_set) or (
+                    base_name and base_name in include_set
                 ):
                     selected.append(dev)
                 else:

--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -211,9 +211,8 @@ async def add_devices(
             # INCLUDE MODE:
             # include exact entity matches OR children of an included parent device
             if include_mode:
-                if (
-                    (dev_name and dev_name in include_set)
-                    or (base_name and base_name in include_set)
+                if (dev_name and dev_name in include_set) or (
+                    base_name and base_name in include_set
                 ):
                     selected.append(dev)
                 else:

--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -133,6 +133,26 @@ async def add_devices(
 
         return None
 
+    def _device_base_name(dev: Entity) -> str | None:
+        """Return the parent/base device name for derived AMP entities."""
+        client = getattr(dev, "_client", None)
+        if client is None:
+            client = getattr(dev, "__dict__", {}).get("_client")
+
+        if not client:
+            return None
+
+        base = (
+            getattr(client, "name", None)
+            or getattr(client, "_attr_name", None)
+            or getattr(client, "_name", None)
+            or getattr(client, "_device_name", None)
+        )
+        if base:
+            return str(base)
+
+        return None
+
     def _device_label(dev: Entity) -> str:
         """Return a compact, stable identifier for logging."""
         name = _device_name(dev)
@@ -167,28 +187,28 @@ async def add_devices(
 
         for dev in devs:
             dev_name = _norm_filter_token(_device_name(dev))
+            base_name = _norm_filter_token(_device_base_name(dev))
 
-            # INCLUDE MODE: only include explicitly listed names
+            # INCLUDE MODE:
+            # include exact entity matches OR children of an included parent device
             if include_mode:
-                if dev_name and dev_name in include_set:
+                if (
+                    (dev_name and dev_name in include_set)
+                    or (base_name and base_name in include_set)
+                ):
                     selected.append(dev)
                 else:
-                    if not dev_name:
-                        _LOGGER.debug(
-                            "%s: Not including device (no name yet): %s",
-                            account,
-                            _device_label(dev),
-                        )
-                    else:
-                        _LOGGER.debug(
-                            "%s: Not including device: %s (match key=%r)",
-                            account,
-                            _device_label(dev),
-                            dev_name,
-                        )
+                    _LOGGER.debug(
+                        "%s: Not including device: %s (match key=%r, base=%r)",
+                        account,
+                        _device_label(dev),
+                        dev_name,
+                        base_name,
+                    )
                 continue
 
-            # EXCLUDE MODE: exclude listed names
+            # EXCLUDE MODE:
+            # preserve exact-match semantics so users can exclude individual entities
             if exclude_set and dev_name and dev_name in exclude_set:
                 _LOGGER.debug(
                     "%s: Excluding device: %s (match key=%r)",

--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -12,7 +12,6 @@ import functools
 import hashlib
 import logging
 from typing import Any, Callable, Optional, TypeVar, overload
-from unittest.mock import Mock
 
 from alexapy import AlexapyLoginCloseRequested, AlexapyLoginError, hide_email
 from alexapy.alexalogin import AlexaLogin
@@ -96,50 +95,31 @@ async def add_devices(
             exclude_filter_set,
         )
 
-    def _explicit_attr(obj: object, attr: str):
-        """Return an explicitly stored attribute, avoiding MagicMock synthesis."""
-        obj_dict = getattr(obj, "__dict__", {})
-        if attr in obj_dict:
-            value = obj_dict[attr]
-            if not isinstance(value, Mock):
-                return value
-        return None
-
-    def _device_name(dev: Entity) -> str | None:
-        """Best-effort name before entity_id is assigned.
-
-        For AMP switches, reconstruct the legacy "<device> <suffix> switch"
-        name only if those attributes were explicitly set.
-        """
-
-        # First prefer explicitly set name attributes (works for tests + most entities)
-        name = (
-            getattr(dev, "name", None)
-            or getattr(dev, "_attr_name", None)
-            or getattr(dev, "_name", None)
-            or getattr(dev, "_device_name", None)
-            or getattr(dev, "_friendly_name", None)
-        )
-        if name:
-            return name
-
-        # Only attempt switch reconstruction if attributes were explicitly defined
-        # (avoids MagicMock auto-attribute trap in tests)
+    def _device_base_name(dev: Entity) -> str | None:
+        """Return the parent/base device name for derived AMP entities."""
+        # Prefer __dict__ first to avoid MagicMock auto-attribute traps in tests,
+        # then fall back to getattr for real entities (descriptors / properties / slots).
         dev_dict = getattr(dev, "__dict__", {})
-
         client = dev_dict.get("_client")
-        suffix = dev_dict.get("_unique_id_suffix")
+        if client is None:
+            client = getattr(dev, "_client", None)
 
-        if client and suffix:
-            client_dict = getattr(client, "__dict__", {})
-            base = (
-                client_dict.get("name")
-                or client_dict.get("_attr_name")
-                or client_dict.get("_name")
-                or client_dict.get("_device_name")
-            )
-            if base:
-                return f"{base} {suffix} switch"
+        if client is None:
+            return None
+
+        client_dict = getattr(client, "__dict__", {})
+        base = (
+            client_dict.get("name")
+            or client_dict.get("_attr_name")
+            or client_dict.get("_name")
+            or client_dict.get("_device_name")
+            or getattr(client, "name", None)
+            or getattr(client, "_attr_name", None)
+            or getattr(client, "_name", None)
+            or getattr(client, "_device_name", None)
+        )
+        if base:
+            return str(base)
 
         return None
 
@@ -211,8 +191,9 @@ async def add_devices(
             # INCLUDE MODE:
             # include exact entity matches OR children of an included parent device
             if include_mode:
-                if (dev_name and dev_name in include_set) or (
-                    base_name and base_name in include_set
+                if (
+                    (dev_name and dev_name in include_set)
+                    or (base_name and base_name in include_set)
                 ):
                     selected.append(dev)
                 else:

--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -12,6 +12,7 @@ import functools
 import hashlib
 import logging
 from typing import Any, Callable, Optional, TypeVar, overload
+from unittest.mock import Mock
 
 from alexapy import AlexapyLoginCloseRequested, AlexapyLoginError, hide_email
 from alexapy.alexalogin import AlexaLogin
@@ -95,6 +96,15 @@ async def add_devices(
             exclude_filter_set,
         )
 
+    def _explicit_attr(obj: object, attr: str):
+        """Return an explicitly stored attribute, avoiding MagicMock synthesis."""
+        obj_dict = getattr(obj, "__dict__", {})
+        if attr in obj_dict:
+            value = obj_dict[attr]
+            if not isinstance(value, Mock):
+                return value
+        return None
+
     def _device_name(dev: Entity) -> str | None:
         """Best-effort name before entity_id is assigned.
 
@@ -135,23 +145,32 @@ async def add_devices(
 
     def _device_base_name(dev: Entity) -> str | None:
         """Return the parent/base device name for derived AMP entities."""
-        client = getattr(dev, "_client", None)
+        client = _explicit_attr(dev, "_client")
         if client is None:
-            client = getattr(dev, "__dict__", {}).get("_client")
+            client = getattr(dev, "_client", None)
 
-        if not client:
+        if not client or isinstance(client, Mock):
             return None
 
         base = (
-            getattr(client, "name", None)
-            or getattr(client, "_attr_name", None)
-            or getattr(client, "_name", None)
-            or getattr(client, "_device_name", None)
+            _explicit_attr(client, "name")
+            or _explicit_attr(client, "_attr_name")
+            or _explicit_attr(client, "_name")
+            or _explicit_attr(client, "_device_name")
         )
-        if base:
-            return str(base)
 
-        return None
+        if base is None:
+            base = (
+                getattr(client, "name", None)
+                or getattr(client, "_attr_name", None)
+                or getattr(client, "_name", None)
+                or getattr(client, "_device_name", None)
+            )
+
+        if not base or isinstance(base, Mock):
+            return None
+
+        return str(base)
 
     def _device_label(dev: Entity) -> str:
         """Return a compact, stable identifier for logging."""
@@ -192,8 +211,9 @@ async def add_devices(
             # INCLUDE MODE:
             # include exact entity matches OR children of an included parent device
             if include_mode:
-                if (dev_name and dev_name in include_set) or (
-                    base_name and base_name in include_set
+                if (
+                    (dev_name and dev_name in include_set)
+                    or (base_name and base_name in include_set)
                 ):
                     selected.append(dev)
                 else:


### PR DESCRIPTION
Fix an issue where `include_devices` required exact entity name matches, causing derived entities (e.g., DND, shuffle, repeat alarms, timers) to be excluded when only the parent device name was specified.

Update filtering logic so include mode also matches entities whose parent device is in include_devices, while preserving exact-match behavior for `exclude_devices`.

This restores expected behavior where including a device also includes its associated AMP entities without impacting existing exclude semantics.

Fixes: Issue #3438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Include-mode filtering now recognizes parent/base device names in addition to exact device names, so child entities are included when their parent is selected.
  * Debug logs now report both exact and derived base match keys for clearer traceability when evaluating devices.

* **Bug Fixes**
  * Exclude-mode remains strict and only excludes on exact device-name matches for predictable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->