### PR TITLE
fix: next_alarm sensor not showing proper snooze state

### DIFF
--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -70,6 +70,8 @@ DEFAULT_PUBLIC_URL = ""
 DEFAULT_QUEUE_DELAY = 1.5
 DEFAULT_SCAN_INTERVAL = 60
 
+EPOCH_MS_THRESHOLD = 10_000_000_000
+
 # Service name constants used by services.py SERVICE_DEFS
 SERVICE_UPDATE_LAST_CALLED = "update_last_called"
 SERVICE_RESTORE_VOLUME = "restore_volume"

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -703,8 +703,10 @@ class AlexaMediaNotificationSensor(SensorEntity):
                 summary,
             )
 
-        return future_active[0][1] if future_active else (
-            self._active[0][1] if self._active else None
+        return (
+            future_active[0][1]
+            if future_active
+            else (self._active[0][1] if self._active else None)
         )
 
     def _process_raw_notifications(self):

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -718,9 +718,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
 
         # Filter ACTIVE (ON / SNOOZED, excluding expired snoozes)
         self._active = (
-            list(filter(_is_active_notification, self._all))
-            if self._all
-            else []
+            list(filter(_is_active_notification, self._all)) if self._all else []
         )
 
         def _coerced_when(item):
@@ -750,7 +748,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
                 ]
             except Exception as exc:
                 summary = f"<error building skipped_past summary: {exc}>"
-        
+
             _LOGGER.debug(
                 "%s: %s %s skipped past notifications: %s",
                 hide_email(self._account),
@@ -758,7 +756,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
                 self._type,
                 summary,
             )
-        
+
         if self._type == "Alarm":
             self._next = (
                 future_active[0][1]

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -718,8 +718,8 @@ class AlexaMediaNotificationSensor(SensorEntity):
         now = dt.now()
 
         # Filter ACTIVE (ON / SNOOZED, excluding expired snoozes)
-        self._active = (
-            list(filter(lambda item: self._is_active_notification(item, now), self._all))
+        self._active = list(
+            filter(lambda item: self._is_active_notification(item, now), self._all)
         )
 
         future_active: list = []

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -669,6 +669,44 @@ class AlexaMediaNotificationSensor(SensorEntity):
         snoozed_to = self._coerce_datetime(item[1].get("snoozedToTime"))
         return snoozed_to is None or snoozed_to > now
 
+    def _select_next_alarm(self, now):
+        """Select next alarm, preferring future active alarms over skipped past ones."""
+        future_active = []
+        skipped_past = []
+
+        for item in self._active:
+            when = self._coerce_datetime(item[1].get(self._sensor_property))
+            if when is not None and when > now:
+                future_active.append(item)
+            else:
+                skipped_past.append((item, when))
+
+        if self._debug and skipped_past:
+            try:
+                summary = [
+                    {
+                        "id": v.get("id"),
+                        "status": v.get("status"),
+                        self._sensor_property: when,
+                        "snoozedToTime": v.get("snoozedToTime"),
+                    }
+                    for (_, v), when in skipped_past
+                ]
+            except (KeyError, TypeError, AttributeError) as exc:
+                summary = f"<error building skipped_past summary: {exc}>"
+
+            _LOGGER.debug(
+                "%s: %s %s skipped past notifications: %s",
+                hide_email(self._account),
+                hide_serial(self._client.device_serial_number),
+                self._type,
+                summary,
+            )
+
+        return future_active[0][1] if future_active else (
+            self._active[0][1] if self._active else None
+        )
+
     def _process_raw_notifications(self):
         # Build full list for this device/type
         self._all = (
@@ -722,44 +760,8 @@ class AlexaMediaNotificationSensor(SensorEntity):
             filter(lambda item: self._is_active_notification(item, now), self._all)
         )
 
-        future_active: list = []
-        skipped_past: list = []
         if self._type == "Alarm":
-            for x in self._active:
-                when = self._coerce_datetime(x[1].get(self._sensor_property))
-                if when is not None and when > now:
-                    future_active.append(x)
-                else:
-                    skipped_past.append((x, when))
-
-        if self._type == "Alarm" and self._debug and skipped_past:
-            try:
-                summary = [
-                    {
-                        "id": v.get("id"),
-                        "status": v.get("status"),
-                        self._sensor_property: when,
-                        "snoozedToTime": v.get("snoozedToTime"),
-                    }
-                    for (_, v), when in skipped_past
-                ]
-            except (KeyError, TypeError, AttributeError) as exc:
-                summary = f"<error building skipped_past summary: {exc}>"
-
-            _LOGGER.debug(
-                "%s: %s %s skipped past notifications: %s",
-                hide_email(self._account),
-                hide_serial(self._client.device_serial_number),
-                self._type,
-                summary,
-            )
-
-        if self._type == "Alarm":
-            self._next = (
-                future_active[0][1]
-                if future_active
-                else (self._active[0][1] if self._active else None)
-            )
+            self._next = self._select_next_alarm(now)
         else:
             self._next = self._active[0][1] if self._active else None
 

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -603,6 +603,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
 
     def _coerce_datetime(self, value) -> Optional[datetime.datetime]:
         """Best-effort conversion of Alexa datetime-ish values to aware datetime."""
+
         def _ensure_aware(parsed: datetime.datetime) -> datetime.datetime:
             if parsed.tzinfo is not None and parsed.utcoffset() is not None:
                 return parsed

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -603,8 +603,16 @@ class AlexaMediaNotificationSensor(SensorEntity):
 
     def _coerce_datetime(self, value) -> Optional[datetime.datetime]:
         """Best-effort conversion of Alexa datetime-ish values to aware datetime."""
+        def _ensure_aware(parsed: datetime.datetime) -> datetime.datetime:
+            if parsed.tzinfo is not None and parsed.utcoffset() is not None:
+                return parsed
+            timezone = dt.get_time_zone(
+                self._client._timezone  # pylint: disable=protected-access
+            )
+            return parsed.replace(tzinfo=timezone or LOCAL_TIMEZONE)
+
         if isinstance(value, datetime.datetime):
-            return value
+            return _ensure_aware(value)
 
         if value in (None, ""):
             return None
@@ -617,15 +625,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
             parsed = dt.parse_datetime(value)
             if parsed is None:
                 return None
-            if parsed.tzinfo is None:
-                timezone = dt.get_time_zone(
-                    self._client._timezone  # pylint: disable=protected-access
-                )
-                if timezone:
-                    parsed = parsed.replace(tzinfo=timezone)
-                else:
-                    parsed = parsed.replace(tzinfo=LOCAL_TIMEZONE)
-            return parsed
+            return _ensure_aware(parsed)
 
         return None
 

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -703,13 +703,70 @@ class AlexaMediaNotificationSensor(SensorEntity):
         # Previous "next" for change detection
         self._prior_value = self._next if self._active else None
 
-        # Filter ACTIVE (ON / SNOOZED)
+        now = dt.now()
+
+        def _is_active_notification(item):
+            status = item[1].get("status")
+            if status == "ON":
+                return True
+
+            if status != "SNOOZED":
+                return False
+
+            snoozed_to = self._coerce_datetime(item[1].get("snoozedToTime"))
+            return snoozed_to is None or snoozed_to > now
+
+        # Filter ACTIVE (ON / SNOOZED, excluding expired snoozes)
         self._active = (
-            list(filter(lambda x: x[1]["status"] in ("ON", "SNOOZED"), self._all))
+            list(filter(_is_active_notification, self._all))
             if self._all
             else []
         )
-        self._next = self._active[0][1] if self._active else None
+
+        def _coerced_when(item):
+            return self._coerce_datetime(item[1].get(self._sensor_property))
+
+        future_active = []
+        skipped_past = []
+
+        for x in self._active:
+            when = _coerced_when(x)
+            if when is not None and when > now:
+                future_active.append(x)
+            else:
+                skipped_past.append((x, when))
+
+        # Debug: log anything we skipped for being in the past
+        if self._type == "Alarm" and self._debug and skipped_past:
+            try:
+                summary = [
+                    {
+                        "id": v.get("id"),
+                        "status": v.get("status"),
+                        self._sensor_property: when,
+                        "snoozedToTime": v.get("snoozedToTime"),
+                    }
+                    for (_, v), when in skipped_past
+                ]
+            except Exception as exc:
+                summary = f"<error building skipped_past summary: {exc}>"
+        
+            _LOGGER.debug(
+                "%s: %s %s skipped past notifications: %s",
+                hide_email(self._account),
+                hide_serial(self._client.device_serial_number),
+                self._type,
+                summary,
+            )
+        
+        if self._type == "Alarm":
+            self._next = (
+                future_active[0][1]
+                if future_active
+                else (self._active[0][1] if self._active else None)
+            )
+        else:
+            self._next = self._active[0][1] if self._active else None
 
         # DEBUG: log ACTIVE set and which one we picked as next
         if self._debug and self._active:

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -657,6 +657,18 @@ class AlexaMediaNotificationSensor(SensorEntity):
 
         return value
 
+    def _is_active_notification(self, item, now):
+        """Return whether a notification should be considered active."""
+        status = item[1].get("status")
+        if status == "ON":
+            return True
+
+        if status != "SNOOZED":
+            return False
+
+        snoozed_to = self._coerce_datetime(item[1].get("snoozedToTime"))
+        return snoozed_to is None or snoozed_to > now
+
     def _process_raw_notifications(self):
         # Build full list for this device/type
         self._all = (
@@ -705,20 +717,9 @@ class AlexaMediaNotificationSensor(SensorEntity):
 
         now = dt.now()
 
-        def _is_active_notification(item):
-            status = item[1].get("status")
-            if status == "ON":
-                return True
-
-            if status != "SNOOZED":
-                return False
-
-            snoozed_to = self._coerce_datetime(item[1].get("snoozedToTime"))
-            return snoozed_to is None or snoozed_to > now
-
         # Filter ACTIVE (ON / SNOOZED, excluding expired snoozes)
         self._active = (
-            list(filter(_is_active_notification, self._all)) if self._all else []
+            list(filter(lambda item: self._is_active_notification(item, now), self._all))
         )
 
         future_active: list = []

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -721,20 +721,16 @@ class AlexaMediaNotificationSensor(SensorEntity):
             list(filter(_is_active_notification, self._all)) if self._all else []
         )
 
-        def _coerced_when(item):
-            return self._coerce_datetime(item[1].get(self._sensor_property))
+        future_active: list = []
+        skipped_past: list = []
+        if self._type == "Alarm":
+            for x in self._active:
+                when = self._coerce_datetime(x[1].get(self._sensor_property))
+                if when is not None and when > now:
+                    future_active.append(x)
+                else:
+                    skipped_past.append((x, when))
 
-        future_active = []
-        skipped_past = []
-
-        for x in self._active:
-            when = _coerced_when(x)
-            if when is not None and when > now:
-                future_active.append(x)
-            else:
-                skipped_past.append((x, when))
-
-        # Debug: log anything we skipped for being in the past
         if self._type == "Alarm" and self._debug and skipped_past:
             try:
                 summary = [
@@ -746,7 +742,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
                     }
                     for (_, v), when in skipped_past
                 ]
-            except Exception as exc:
+            except (KeyError, TypeError, AttributeError) as exc:
                 summary = f"<error building skipped_past summary: {exc}>"
 
             _LOGGER.debug(

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -45,6 +45,7 @@ from .const import (
     ALEXA_ICON_DEFAULT,
     ALEXA_UNIT_CONVERSION,
     CONF_DEBUG,
+    EPOCH_MS_THRESHOLD,
     RECURRING_DAY,
     RECURRING_PATTERN,
     RECURRING_PATTERN_ISO_SET,
@@ -619,7 +620,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
             return None
 
         if isinstance(value, (int, float)):
-            ts = value / 1000 if value > 10_000_000_000 else value
+            ts = value / 1000 if value > EPOCH_MS_THRESHOLD else value
             return datetime.datetime.fromtimestamp(ts, tz=LOCAL_TIMEZONE)
 
         if isinstance(value, str):

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -683,18 +683,15 @@ class AlexaMediaNotificationSensor(SensorEntity):
                 skipped_past.append((item, when))
 
         if self._debug and skipped_past:
-            try:
-                summary = [
-                    {
-                        "id": v.get("id"),
-                        "status": v.get("status"),
-                        self._sensor_property: when,
-                        "snoozedToTime": v.get("snoozedToTime"),
-                    }
-                    for (_, v), when in skipped_past
-                ]
-            except (KeyError, TypeError, AttributeError) as exc:
-                summary = f"<error building skipped_past summary: {exc}>"
+            summary = [
+                {
+                    "id": v.get("id"),
+                    "status": v.get("status"),
+                    self._sensor_property: when,
+                    "snoozedToTime": v.get("snoozedToTime"),
+                }
+                for (_, v), when in skipped_past
+            ]
 
             _LOGGER.debug(
                 "%s: %s %s skipped past notifications: %s",

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -601,6 +601,61 @@ class AlexaMediaNotificationSensor(SensorEntity):
         self._amz_id: Optional[str] = None
         self._version: Optional[str] = None
 
+    def _coerce_datetime(self, value) -> Optional[datetime.datetime]:
+        """Best-effort conversion of Alexa datetime-ish values to aware datetime."""
+        if isinstance(value, datetime.datetime):
+            return value
+
+        if value in (None, ""):
+            return None
+
+        if isinstance(value, (int, float)):
+            ts = value / 1000 if value > 10_000_000_000 else value
+            return datetime.datetime.fromtimestamp(ts, tz=LOCAL_TIMEZONE)
+
+        if isinstance(value, str):
+            parsed = dt.parse_datetime(value)
+            if parsed is None:
+                return None
+            if parsed.tzinfo is None:
+                timezone = dt.get_time_zone(
+                    self._client._timezone  # pylint: disable=protected-access
+                )
+                if timezone:
+                    parsed = parsed.replace(tzinfo=timezone)
+                else:
+                    parsed = parsed.replace(tzinfo=LOCAL_TIMEZONE)
+            return parsed
+
+        return None
+
+    def _normalize_alarm_snooze_state(self, value):
+        """Normalize snoozed alarm state before sorting/selecting next."""
+        if self._type != "Alarm" or not value:
+            return value
+
+        next_item = value[1]
+        if not isinstance(next_item, dict):
+            return value
+
+        status = next_item.get("status")
+        snoozed_to = self._coerce_datetime(next_item.get("snoozedToTime"))
+        alarm_when = self._coerce_datetime(next_item.get(self._sensor_property))
+        now = dt.now()
+
+        if snoozed_to and snoozed_to > now:
+            next_item["status"] = "SNOOZED"
+            next_item["snoozedToTime"] = snoozed_to
+            next_item[self._sensor_property] = snoozed_to
+            return value
+
+        if status == "SNOOZED" and snoozed_to is None and alarm_when is not None:
+            next_item["snoozedToTime"] = alarm_when
+            next_item[self._sensor_property] = alarm_when
+            return value
+
+        return value
+
     def _process_raw_notifications(self):
         # Build full list for this device/type
         self._all = (
@@ -608,6 +663,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
             if self._n_dict
             else []
         )
+        self._all = list(map(self._normalize_alarm_snooze_state, self._all))
         self._all = list(map(self._update_recurring_alarm, self._all))
         self._all = sorted(self._all, key=lambda x: x[1][self._sensor_property])
 
@@ -619,6 +675,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
                         "id": v.get("id"),
                         "status": v.get("status"),
                         self._sensor_property: v.get(self._sensor_property),
+                        "snoozedToTime": v.get("snoozedToTime"),
                         "lastUpdatedDate": v.get("lastUpdatedDate"),
                         "type": v.get("type"),
                     }
@@ -661,6 +718,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
                         "id": v.get("id"),
                         "status": v.get("status"),
                         self._sensor_property: v.get(self._sensor_property),
+                        "snoozedToTime": v.get("snoozedToTime"),
                         "lastUpdatedDate": v.get("lastUpdatedDate"),
                         "type": v.get("type"),
                     }
@@ -784,7 +842,18 @@ class AlexaMediaNotificationSensor(SensorEntity):
                     datetime.datetime.fromtimestamp(alarm / 1000, tz=LOCAL_TIMEZONE)
                 )
             )
-        alarm_on = next_item["status"] == "ON"
+        alarm_status = next_item.get("status")
+        alarm_on = alarm_status == "ON"
+        alarm_snoozed = alarm_status == "SNOOZED"
+
+        # Preserve snoozed alarms exactly as normalized above.
+        if alarm_snoozed:
+            if reminder:
+                alarm = dt.as_timestamp(alarm) * 1000
+            if alarm != next_item[self._sensor_property]:
+                next_item[self._sensor_property] = alarm
+            return value
+
         r_rule_data = next_item.get("rRuleData")
         if r_rule_data:
             next_trigger_times = r_rule_data.get("nextTriggerTimes")

--- a/tests/test_sensor_snooze.py
+++ b/tests/test_sensor_snooze.py
@@ -18,6 +18,7 @@ UTC = datetime.timezone.utc
 # Shared helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_alarm_sensor():
     """Return a bare AlexaMediaNotificationSensor wired for Alarm type."""
     sensor = object.__new__(AlexaMediaNotificationSensor)
@@ -46,6 +47,7 @@ def _alarm_value(status, alarm_time, snoozed_to=None):
 # 1. _normalize_alarm_snooze_state — four states
 # ---------------------------------------------------------------------------
 
+
 class TestNormalizeAlarmSnoozeState:
     """Unit tests for _normalize_alarm_snooze_state."""
 
@@ -59,7 +61,9 @@ class TestNormalizeAlarmSnoozeState:
         alarm_at = self.NOW + datetime.timedelta(hours=1)
         value = _alarm_value("ON", alarm_at, snoozed_to=None)
 
-        with patch("custom_components.alexa_media.sensor.dt.now", return_value=self.NOW):
+        with patch(
+            "custom_components.alexa_media.sensor.dt.now", return_value=self.NOW
+        ):
             result = sensor._normalize_alarm_snooze_state(value)
 
         assert result[1]["status"] == "ON"
@@ -72,11 +76,13 @@ class TestNormalizeAlarmSnoozeState:
         """When snoozedToTime is in the future, status must become SNOOZED
         and alarmTime must be updated to the snooze time."""
         sensor = _make_alarm_sensor()
-        original_alarm = self.NOW - datetime.timedelta(minutes=5)   # already rang
-        snooze_until = self.NOW + datetime.timedelta(minutes=9)      # snooze active
+        original_alarm = self.NOW - datetime.timedelta(minutes=5)  # already rang
+        snooze_until = self.NOW + datetime.timedelta(minutes=9)  # snooze active
         value = _alarm_value("ON", original_alarm, snoozed_to=snooze_until)
 
-        with patch("custom_components.alexa_media.sensor.dt.now", return_value=self.NOW):
+        with patch(
+            "custom_components.alexa_media.sensor.dt.now", return_value=self.NOW
+        ):
             result = sensor._normalize_alarm_snooze_state(value)
 
         assert result[1]["status"] == "SNOOZED"
@@ -87,9 +93,13 @@ class TestNormalizeAlarmSnoozeState:
         """Future snoozedToTime normalizes regardless of original status value."""
         sensor = _make_alarm_sensor()
         snooze_until = self.NOW + datetime.timedelta(minutes=3)
-        value = _alarm_value("SNOOZED", self.NOW - datetime.timedelta(hours=1), snoozed_to=snooze_until)
+        value = _alarm_value(
+            "SNOOZED", self.NOW - datetime.timedelta(hours=1), snoozed_to=snooze_until
+        )
 
-        with patch("custom_components.alexa_media.sensor.dt.now", return_value=self.NOW):
+        with patch(
+            "custom_components.alexa_media.sensor.dt.now", return_value=self.NOW
+        ):
             result = sensor._normalize_alarm_snooze_state(value)
 
         assert result[1]["status"] == "SNOOZED"
@@ -104,7 +114,9 @@ class TestNormalizeAlarmSnoozeState:
         alarm_at = self.NOW + datetime.timedelta(minutes=5)
         value = _alarm_value("SNOOZED", alarm_at, snoozed_to=None)
 
-        with patch("custom_components.alexa_media.sensor.dt.now", return_value=self.NOW):
+        with patch(
+            "custom_components.alexa_media.sensor.dt.now", return_value=self.NOW
+        ):
             result = sensor._normalize_alarm_snooze_state(value)
 
         assert result[1]["status"] == "SNOOZED"
@@ -121,7 +133,9 @@ class TestNormalizeAlarmSnoozeState:
         original_alarm = self.NOW - datetime.timedelta(hours=1)
         value = _alarm_value("SNOOZED", original_alarm, snoozed_to=expired_snooze)
 
-        with patch("custom_components.alexa_media.sensor.dt.now", return_value=self.NOW):
+        with patch(
+            "custom_components.alexa_media.sensor.dt.now", return_value=self.NOW
+        ):
             result = sensor._normalize_alarm_snooze_state(value)
 
         # normalize does not touch expired snooze; filtering is done elsewhere
@@ -138,7 +152,9 @@ class TestNormalizeAlarmSnoozeState:
         alarm_at = self.NOW + datetime.timedelta(hours=1)
         value = _alarm_value("SNOOZED", alarm_at)
 
-        with patch("custom_components.alexa_media.sensor.dt.now", return_value=self.NOW):
+        with patch(
+            "custom_components.alexa_media.sensor.dt.now", return_value=self.NOW
+        ):
             result = sensor._normalize_alarm_snooze_state(value)
 
         assert result is value  # exact same object, no copy
@@ -147,6 +163,7 @@ class TestNormalizeAlarmSnoozeState:
 # ---------------------------------------------------------------------------
 # 2. Active-notification filter — replicates _is_active_notification closure
 # ---------------------------------------------------------------------------
+
 
 class TestIsActiveNotification:
     """Unit tests for the _is_active_notification logic in _process_raw_notifications.
@@ -197,7 +214,9 @@ class TestIsActiveNotification:
     def test_snoozed_none_snooze_time_treated_as_active(self):
         """SNOOZED alarm with snoozedToTime=None is treated as active (fail-open)."""
         sensor = _make_alarm_sensor()
-        item = _alarm_value("SNOOZED", self.NOW + datetime.timedelta(hours=1), snoozed_to=None)
+        item = _alarm_value(
+            "SNOOZED", self.NOW + datetime.timedelta(hours=1), snoozed_to=None
+        )
         assert self._is_active(sensor, item, self.NOW) is True
 
     # --- State 4: expired SNOOZED ---
@@ -206,7 +225,9 @@ class TestIsActiveNotification:
         """SNOOZED alarm whose snoozedToTime is in the past must be excluded."""
         sensor = _make_alarm_sensor()
         expired_snooze = self.NOW - datetime.timedelta(minutes=5)
-        item = _alarm_value("SNOOZED", self.NOW - datetime.timedelta(hours=1), snoozed_to=expired_snooze)
+        item = _alarm_value(
+            "SNOOZED", self.NOW - datetime.timedelta(hours=1), snoozed_to=expired_snooze
+        )
         assert self._is_active(sensor, item, self.NOW) is False
 
     def test_expired_snooze_at_exact_boundary_is_not_active(self):

--- a/tests/test_sensor_snooze.py
+++ b/tests/test_sensor_snooze.py
@@ -42,7 +42,7 @@ def _alarm_value(status, alarm_time, snoozed_to=None):
 
 
 # ---------------------------------------------------------------------------
-# 1. _normalize_alarm_snooze_state — four states
+# 1. _coerce_datetime
 # ---------------------------------------------------------------------------
 
 
@@ -123,6 +123,11 @@ class TestCoerceDatetime:
         assert result == expected
         assert result.utcoffset() == datetime.timedelta(0)
         assert result.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# 2. _normalize_alarm_snooze_state — four states
+# ---------------------------------------------------------------------------
 
 
 class TestNormalizeAlarmSnoozeState:
@@ -239,7 +244,7 @@ class TestNormalizeAlarmSnoozeState:
 
 
 # ---------------------------------------------------------------------------
-# 2. Active-notification filter
+# 3. Active-notification filter
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_sensor_snooze.py
+++ b/tests/test_sensor_snooze.py
@@ -161,30 +161,13 @@ class TestNormalizeAlarmSnoozeState:
 
 
 # ---------------------------------------------------------------------------
-# 2. Active-notification filter — replicates _is_active_notification closure
+# 2. Active-notification filter
 # ---------------------------------------------------------------------------
 
 
 class TestIsActiveNotification:
-    """Unit tests for the _is_active_notification logic in _process_raw_notifications.
-
-    Because _is_active_notification is a nested closure, its logic is replicated
-    here using the public _coerce_datetime method so the behaviour is tested
-    without requiring a full HA environment setup.
-    """
-
+    """Unit tests for _is_active_notification."""
     NOW = datetime.datetime(2024, 6, 1, 8, 0, 0, tzinfo=UTC)
-
-    @staticmethod
-    def _is_active(sensor, item, now):
-        """Mirror the _is_active_notification closure from _process_raw_notifications."""
-        status = item[1].get("status")
-        if status == "ON":
-            return True
-        if status != "SNOOZED":
-            return False
-        snoozed_to = sensor._coerce_datetime(item[1].get("snoozedToTime"))
-        return snoozed_to is None or snoozed_to > now
 
     # --- State 1: ON ---
 
@@ -192,13 +175,13 @@ class TestIsActiveNotification:
         """ON alarm must always be considered active."""
         sensor = _make_alarm_sensor()
         item = _alarm_value("ON", self.NOW + datetime.timedelta(hours=1))
-        assert self._is_active(sensor, item, self.NOW) is True
+        assert sensor._is_active_notification(item, self.NOW) is True
 
     def test_on_alarm_is_active_even_if_in_past(self):
         """ON alarm is active regardless of whether alarmTime is past."""
         sensor = _make_alarm_sensor()
         item = _alarm_value("ON", self.NOW - datetime.timedelta(hours=2))
-        assert self._is_active(sensor, item, self.NOW) is True
+        assert sensor._is_active_notification(item, self.NOW) is True
 
     # --- State 2: SNOOZED with future snoozedToTime ---
 
@@ -207,7 +190,7 @@ class TestIsActiveNotification:
         sensor = _make_alarm_sensor()
         snooze_until = self.NOW + datetime.timedelta(minutes=9)
         item = _alarm_value("SNOOZED", self.NOW, snoozed_to=snooze_until)
-        assert self._is_active(sensor, item, self.NOW) is True
+        assert sensor._is_active_notification(item, self.NOW) is True
 
     # --- State 3: SNOOZED with missing snoozedToTime ---
 
@@ -217,7 +200,7 @@ class TestIsActiveNotification:
         item = _alarm_value(
             "SNOOZED", self.NOW + datetime.timedelta(hours=1), snoozed_to=None
         )
-        assert self._is_active(sensor, item, self.NOW) is True
+        assert sensor._is_active_notification(item, self.NOW) is True
 
     # --- State 4: expired SNOOZED ---
 
@@ -228,13 +211,13 @@ class TestIsActiveNotification:
         item = _alarm_value(
             "SNOOZED", self.NOW - datetime.timedelta(hours=1), snoozed_to=expired_snooze
         )
-        assert self._is_active(sensor, item, self.NOW) is False
+        assert sensor._is_active_notification(item, self.NOW) is False
 
     def test_expired_snooze_at_exact_boundary_is_not_active(self):
         """snoozedToTime == now (not strictly greater) is treated as expired."""
         sensor = _make_alarm_sensor()
         item = _alarm_value("SNOOZED", self.NOW, snoozed_to=self.NOW)
-        assert self._is_active(sensor, item, self.NOW) is False
+        assert sensor._is_active_notification(item, self.NOW) is False
 
     # --- Unrelated statuses ---
 
@@ -242,4 +225,4 @@ class TestIsActiveNotification:
         """OFF alarm must never be active."""
         sensor = _make_alarm_sensor()
         item = _alarm_value("OFF", self.NOW + datetime.timedelta(hours=1))
-        assert self._is_active(sensor, item, self.NOW) is False
+        assert sensor._is_active_notification(item, self.NOW) is False

--- a/tests/test_sensor_snooze.py
+++ b/tests/test_sensor_snooze.py
@@ -1,0 +1,224 @@
+"""Pytest cases for the four key alarm snooze states.
+
+Covers _normalize_alarm_snooze_state and the _is_active_notification
+filter logic introduced in PR `#3440`.
+"""
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.alexa_media.sensor import AlexaMediaNotificationSensor
+
+UTC = datetime.timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_alarm_sensor():
+    """Return a bare AlexaMediaNotificationSensor wired for Alarm type."""
+    sensor = object.__new__(AlexaMediaNotificationSensor)
+    sensor._type = "Alarm"
+    sensor._sensor_property = "alarmTime"
+    client = MagicMock()
+    client._timezone = "UTC"
+    sensor._client = client
+    return sensor
+
+
+def _alarm_value(status, alarm_time, snoozed_to=None):
+    """Build a (key, dict) tuple as produced by _fix_alarm_date_time."""
+    return (
+        "test_alarm_id",
+        {
+            "status": status,
+            "alarmTime": alarm_time,
+            "snoozedToTime": snoozed_to,
+            "type": "Alarm",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. _normalize_alarm_snooze_state — four states
+# ---------------------------------------------------------------------------
+
+class TestNormalizeAlarmSnoozeState:
+    """Unit tests for _normalize_alarm_snooze_state."""
+
+    NOW = datetime.datetime(2024, 6, 1, 8, 0, 0, tzinfo=UTC)
+
+    # --- State 1: ON ---
+
+    def test_on_alarm_passes_through_unchanged(self):
+        """ON alarm with no snoozedToTime must not be modified."""
+        sensor = _make_alarm_sensor()
+        alarm_at = self.NOW + datetime.timedelta(hours=1)
+        value = _alarm_value("ON", alarm_at, snoozed_to=None)
+
+        with patch("custom_components.alexa_media.sensor.dt.now", return_value=self.NOW):
+            result = sensor._normalize_alarm_snooze_state(value)
+
+        assert result[1]["status"] == "ON"
+        assert result[1]["alarmTime"] == alarm_at
+        assert result[1]["snoozedToTime"] is None
+
+    # --- State 2: SNOOZED with future snoozedToTime ---
+
+    def test_future_snoozed_to_time_sets_status_and_updates_timestamp(self):
+        """When snoozedToTime is in the future, status must become SNOOZED
+        and alarmTime must be updated to the snooze time."""
+        sensor = _make_alarm_sensor()
+        original_alarm = self.NOW - datetime.timedelta(minutes=5)   # already rang
+        snooze_until = self.NOW + datetime.timedelta(minutes=9)      # snooze active
+        value = _alarm_value("ON", original_alarm, snoozed_to=snooze_until)
+
+        with patch("custom_components.alexa_media.sensor.dt.now", return_value=self.NOW):
+            result = sensor._normalize_alarm_snooze_state(value)
+
+        assert result[1]["status"] == "SNOOZED"
+        assert result[1]["alarmTime"] == snooze_until
+        assert result[1]["snoozedToTime"] == snooze_until
+
+    def test_future_snoozed_to_time_overrides_existing_snoozed_status(self):
+        """Future snoozedToTime normalizes regardless of original status value."""
+        sensor = _make_alarm_sensor()
+        snooze_until = self.NOW + datetime.timedelta(minutes=3)
+        value = _alarm_value("SNOOZED", self.NOW - datetime.timedelta(hours=1), snoozed_to=snooze_until)
+
+        with patch("custom_components.alexa_media.sensor.dt.now", return_value=self.NOW):
+            result = sensor._normalize_alarm_snooze_state(value)
+
+        assert result[1]["status"] == "SNOOZED"
+        assert result[1]["alarmTime"] == snooze_until
+
+    # --- State 3: SNOOZED with missing snoozedToTime ---
+
+    def test_snoozed_missing_snooze_time_backfills_from_alarm_time(self):
+        """SNOOZED alarm whose snoozedToTime is None must have snoozedToTime
+        backfilled from alarmTime."""
+        sensor = _make_alarm_sensor()
+        alarm_at = self.NOW + datetime.timedelta(minutes=5)
+        value = _alarm_value("SNOOZED", alarm_at, snoozed_to=None)
+
+        with patch("custom_components.alexa_media.sensor.dt.now", return_value=self.NOW):
+            result = sensor._normalize_alarm_snooze_state(value)
+
+        assert result[1]["status"] == "SNOOZED"
+        assert result[1]["snoozedToTime"] == alarm_at
+        assert result[1]["alarmTime"] == alarm_at
+
+    # --- State 4: expired SNOOZED ---
+
+    def test_expired_snoozed_left_unchanged_by_normalize(self):
+        """SNOOZED alarm whose snoozedToTime is in the past must not be modified
+        by normalization (exclusion is handled downstream by the active filter)."""
+        sensor = _make_alarm_sensor()
+        expired_snooze = self.NOW - datetime.timedelta(minutes=5)
+        original_alarm = self.NOW - datetime.timedelta(hours=1)
+        value = _alarm_value("SNOOZED", original_alarm, snoozed_to=expired_snooze)
+
+        with patch("custom_components.alexa_media.sensor.dt.now", return_value=self.NOW):
+            result = sensor._normalize_alarm_snooze_state(value)
+
+        # normalize does not touch expired snooze; filtering is done elsewhere
+        assert result[1]["status"] == "SNOOZED"
+        assert result[1]["snoozedToTime"] == expired_snooze
+        assert result[1]["alarmTime"] == original_alarm
+
+    # --- Non-Alarm type guard ---
+
+    def test_non_alarm_type_skipped(self):
+        """Non-Alarm sensors must be returned unchanged regardless of payload."""
+        sensor = _make_alarm_sensor()
+        sensor._type = "Reminder"
+        alarm_at = self.NOW + datetime.timedelta(hours=1)
+        value = _alarm_value("SNOOZED", alarm_at)
+
+        with patch("custom_components.alexa_media.sensor.dt.now", return_value=self.NOW):
+            result = sensor._normalize_alarm_snooze_state(value)
+
+        assert result is value  # exact same object, no copy
+
+
+# ---------------------------------------------------------------------------
+# 2. Active-notification filter — replicates _is_active_notification closure
+# ---------------------------------------------------------------------------
+
+class TestIsActiveNotification:
+    """Unit tests for the _is_active_notification logic in _process_raw_notifications.
+
+    Because _is_active_notification is a nested closure, its logic is replicated
+    here using the public _coerce_datetime method so the behaviour is tested
+    without requiring a full HA environment setup.
+    """
+
+    NOW = datetime.datetime(2024, 6, 1, 8, 0, 0, tzinfo=UTC)
+
+    `@staticmethod`
+    def _is_active(sensor, item, now):
+        """Mirror the _is_active_notification closure from _process_raw_notifications."""
+        status = item[1].get("status")
+        if status == "ON":
+            return True
+        if status != "SNOOZED":
+            return False
+        snoozed_to = sensor._coerce_datetime(item[1].get("snoozedToTime"))
+        return snoozed_to is None or snoozed_to > now
+
+    # --- State 1: ON ---
+
+    def test_on_alarm_is_active(self):
+        """ON alarm must always be considered active."""
+        sensor = _make_alarm_sensor()
+        item = _alarm_value("ON", self.NOW + datetime.timedelta(hours=1))
+        assert self._is_active(sensor, item, self.NOW) is True
+
+    def test_on_alarm_is_active_even_if_in_past(self):
+        """ON alarm is active regardless of whether alarmTime is past."""
+        sensor = _make_alarm_sensor()
+        item = _alarm_value("ON", self.NOW - datetime.timedelta(hours=2))
+        assert self._is_active(sensor, item, self.NOW) is True
+
+    # --- State 2: SNOOZED with future snoozedToTime ---
+
+    def test_snoozed_future_snooze_time_is_active(self):
+        """SNOOZED alarm whose snoozedToTime is still in the future must be active."""
+        sensor = _make_alarm_sensor()
+        snooze_until = self.NOW + datetime.timedelta(minutes=9)
+        item = _alarm_value("SNOOZED", self.NOW, snoozed_to=snooze_until)
+        assert self._is_active(sensor, item, self.NOW) is True
+
+    # --- State 3: SNOOZED with missing snoozedToTime ---
+
+    def test_snoozed_none_snooze_time_treated_as_active(self):
+        """SNOOZED alarm with snoozedToTime=None is treated as active (fail-open)."""
+        sensor = _make_alarm_sensor()
+        item = _alarm_value("SNOOZED", self.NOW + datetime.timedelta(hours=1), snoozed_to=None)
+        assert self._is_active(sensor, item, self.NOW) is True
+
+    # --- State 4: expired SNOOZED ---
+
+    def test_expired_snoozed_is_not_active(self):
+        """SNOOZED alarm whose snoozedToTime is in the past must be excluded."""
+        sensor = _make_alarm_sensor()
+        expired_snooze = self.NOW - datetime.timedelta(minutes=5)
+        item = _alarm_value("SNOOZED", self.NOW - datetime.timedelta(hours=1), snoozed_to=expired_snooze)
+        assert self._is_active(sensor, item, self.NOW) is False
+
+    def test_expired_snooze_at_exact_boundary_is_not_active(self):
+        """snoozedToTime == now (not strictly greater) is treated as expired."""
+        sensor = _make_alarm_sensor()
+        item = _alarm_value("SNOOZED", self.NOW, snoozed_to=self.NOW)
+        assert self._is_active(sensor, item, self.NOW) is False
+
+    # --- Unrelated statuses ---
+
+    def test_off_alarm_is_not_active(self):
+        """OFF alarm must never be active."""
+        sensor = _make_alarm_sensor()
+        item = _alarm_value("OFF", self.NOW + datetime.timedelta(hours=1))
+        assert self._is_active(sensor, item, self.NOW) is False

--- a/tests/test_sensor_snooze.py
+++ b/tests/test_sensor_snooze.py
@@ -123,6 +123,7 @@ class TestCoerceDatetime:
         assert result.utcoffset() == datetime.timedelta(0)
         assert result.tzinfo is not None
 
+
 class TestNormalizeAlarmSnoozeState:
     """Unit tests for _normalize_alarm_snooze_state."""
 

--- a/tests/test_sensor_snooze.py
+++ b/tests/test_sensor_snooze.py
@@ -49,13 +49,11 @@ def _alarm_value(status, alarm_time, snoozed_to=None):
 class TestCoerceDatetime:
     """Unit tests for _coerce_datetime."""
 
-    UTC = datetime.timezone.utc
-
     def test_aware_datetime_passes_through_unchanged(self):
         """Aware datetimes should be returned unchanged."""
         sensor = _make_alarm_sensor()
 
-        aware = datetime.datetime(2024, 6, 1, 8, 0, tzinfo=self.UTC)
+        aware = datetime.datetime(2024, 6, 1, 8, 0, tzinfo=UTC)
 
         result = sensor._coerce_datetime(aware)
 
@@ -69,7 +67,7 @@ class TestCoerceDatetime:
 
         result = sensor._coerce_datetime(epoch_seconds)
 
-        expected = datetime.datetime.fromtimestamp(epoch_seconds, tz=self.UTC)
+        expected = datetime.datetime.fromtimestamp(epoch_seconds, tz=UTC)
 
         assert result == expected  # equality compares instants
         assert result.tzinfo is not None
@@ -83,7 +81,7 @@ class TestCoerceDatetime:
 
         result = sensor._coerce_datetime(epoch_ms)
 
-        expected = datetime.datetime.fromtimestamp(epoch_ms / 1000, tz=self.UTC)
+        expected = datetime.datetime.fromtimestamp(epoch_ms / 1000, tz=UTC)
 
         assert result == expected
         assert result.tzinfo is not None
@@ -94,7 +92,7 @@ class TestCoerceDatetime:
 
         result = sensor._coerce_datetime("2024-06-01T08:00:00+00:00")
 
-        expected = datetime.datetime(2024, 6, 1, 8, 0, tzinfo=self.UTC)
+        expected = datetime.datetime(2024, 6, 1, 8, 0, tzinfo=UTC)
 
         assert result == expected
 
@@ -110,19 +108,23 @@ class TestCoerceDatetime:
 
         assert sensor._coerce_datetime("") is None
 
-    def test_naive_datetime_made_aware_using_sensor_timezone(self):
+    def test_naive_datetime_made_aware_using_sensor_timezone(self, monkeypatch):
         """Naive datetimes should be localized using sensor timezone."""
         sensor = _make_alarm_sensor()
+        monkeypatch.setattr(
+            "custom_components.alexa_media.sensor.dt.get_time_zone",
+            lambda _: UTC,
+        )
 
         naive = datetime.datetime(2024, 6, 1, 8, 0)
 
         result = sensor._coerce_datetime(naive)
 
-        expected = naive.replace(tzinfo=result.tzinfo)
+        expected = naive.replace(tzinfo=UTC)
 
         assert result == expected
-        assert result.utcoffset() == datetime.timedelta(0)
         assert result.tzinfo is not None
+        assert result.utcoffset() is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor_snooze.py
+++ b/tests/test_sensor_snooze.py
@@ -7,8 +7,6 @@ filter logic introduced in PR `#3440`.
 import datetime
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from custom_components.alexa_media.sensor import AlexaMediaNotificationSensor
 
 UTC = datetime.timezone.utc
@@ -23,7 +21,7 @@ def _make_alarm_sensor():
     """Return a bare AlexaMediaNotificationSensor wired for Alarm type."""
     sensor = object.__new__(AlexaMediaNotificationSensor)
     sensor._type = "Alarm"
-    sensor._sensor_property = "alarmTime"
+    sensor._sensor_property = "date_time"
     client = MagicMock()
     client._timezone = "UTC"
     sensor._client = client
@@ -36,7 +34,7 @@ def _alarm_value(status, alarm_time, snoozed_to=None):
         "test_alarm_id",
         {
             "status": status,
-            "alarmTime": alarm_time,
+            "date_time": alarm_time,
             "snoozedToTime": snoozed_to,
             "type": "Alarm",
         },
@@ -46,6 +44,89 @@ def _alarm_value(status, alarm_time, snoozed_to=None):
 # ---------------------------------------------------------------------------
 # 1. _normalize_alarm_snooze_state — four states
 # ---------------------------------------------------------------------------
+
+
+class TestCoerceDatetime:
+    """Unit tests for _coerce_datetime."""
+
+    UTC = datetime.timezone.utc
+
+    def test_aware_datetime_passes_through_unchanged(self):
+        """Aware datetimes should be returned unchanged."""
+        sensor = _make_alarm_sensor()
+
+        aware = datetime.datetime(2024, 6, 1, 8, 0, tzinfo=self.UTC)
+
+        result = sensor._coerce_datetime(aware)
+
+        assert result is aware
+
+    def test_epoch_seconds_converted_correctly(self):
+        """Epoch timestamps in seconds should convert correctly."""
+        sensor = _make_alarm_sensor()
+
+        epoch_seconds = 1717228800  # 2024-06-01 08:00:00 UTC
+
+        result = sensor._coerce_datetime(epoch_seconds)
+
+        expected = datetime.datetime.fromtimestamp(
+            epoch_seconds, tz=self.UTC
+        )
+
+        assert result == expected
+        assert result.tzinfo == self.UTC
+
+    def test_epoch_milliseconds_converted_correctly(self):
+        """Epoch timestamps in milliseconds should convert correctly."""
+        sensor = _make_alarm_sensor()
+
+        epoch_ms = 1717228800000  # 2024-06-01 08:00:00 UTC
+
+        result = sensor._coerce_datetime(epoch_ms)
+
+        expected = datetime.datetime.fromtimestamp(
+            epoch_ms / 1000, tz=self.UTC
+        )
+
+        assert result == expected
+        assert result.tzinfo == self.UTC
+
+    def test_iso_datetime_string_parsed_correctly(self):
+        """ISO datetime strings should parse into aware datetimes."""
+        sensor = _make_alarm_sensor()
+
+        result = sensor._coerce_datetime("2024-06-01T08:00:00+00:00")
+
+        expected = datetime.datetime(
+            2024, 6, 1, 8, 0, tzinfo=self.UTC
+        )
+
+        assert result == expected
+
+    def test_none_returns_none(self):
+        """None should short-circuit to None."""
+        sensor = _make_alarm_sensor()
+
+        assert sensor._coerce_datetime(None) is None
+
+    def test_empty_string_returns_none(self):
+        """Empty string should short-circuit to None."""
+        sensor = _make_alarm_sensor()
+
+        assert sensor._coerce_datetime("") is None
+
+    def test_naive_datetime_made_aware_using_sensor_timezone(self):
+        """Naive datetimes should be localized using sensor timezone."""
+        sensor = _make_alarm_sensor()
+
+        naive = datetime.datetime(2024, 6, 1, 8, 0)
+
+        result = sensor._coerce_datetime(naive)
+
+        expected = naive.replace(tzinfo=self.UTC)
+
+        assert result == expected
+        assert result.tzinfo == self.UTC
 
 
 class TestNormalizeAlarmSnoozeState:
@@ -67,14 +148,14 @@ class TestNormalizeAlarmSnoozeState:
             result = sensor._normalize_alarm_snooze_state(value)
 
         assert result[1]["status"] == "ON"
-        assert result[1]["alarmTime"] == alarm_at
+        assert result[1]["date_time"] == alarm_at
         assert result[1]["snoozedToTime"] is None
 
     # --- State 2: SNOOZED with future snoozedToTime ---
 
     def test_future_snoozed_to_time_sets_status_and_updates_timestamp(self):
         """When snoozedToTime is in the future, status must become SNOOZED
-        and alarmTime must be updated to the snooze time."""
+        and date_time must be updated to the snooze time."""
         sensor = _make_alarm_sensor()
         original_alarm = self.NOW - datetime.timedelta(minutes=5)  # already rang
         snooze_until = self.NOW + datetime.timedelta(minutes=9)  # snooze active
@@ -86,7 +167,7 @@ class TestNormalizeAlarmSnoozeState:
             result = sensor._normalize_alarm_snooze_state(value)
 
         assert result[1]["status"] == "SNOOZED"
-        assert result[1]["alarmTime"] == snooze_until
+        assert result[1]["date_time"] == snooze_until
         assert result[1]["snoozedToTime"] == snooze_until
 
     def test_future_snoozed_to_time_overrides_existing_snoozed_status(self):
@@ -103,13 +184,14 @@ class TestNormalizeAlarmSnoozeState:
             result = sensor._normalize_alarm_snooze_state(value)
 
         assert result[1]["status"] == "SNOOZED"
-        assert result[1]["alarmTime"] == snooze_until
+        assert result[1]["date_time"] == snooze_until
+        assert result[1]["snoozedToTime"] == snooze_until
 
     # --- State 3: SNOOZED with missing snoozedToTime ---
 
     def test_snoozed_missing_snooze_time_backfills_from_alarm_time(self):
         """SNOOZED alarm whose snoozedToTime is None must have snoozedToTime
-        backfilled from alarmTime."""
+        backfilled from date_time."""
         sensor = _make_alarm_sensor()
         alarm_at = self.NOW + datetime.timedelta(minutes=5)
         value = _alarm_value("SNOOZED", alarm_at, snoozed_to=None)
@@ -121,7 +203,7 @@ class TestNormalizeAlarmSnoozeState:
 
         assert result[1]["status"] == "SNOOZED"
         assert result[1]["snoozedToTime"] == alarm_at
-        assert result[1]["alarmTime"] == alarm_at
+        assert result[1]["date_time"] == alarm_at
 
     # --- State 4: expired SNOOZED ---
 
@@ -141,7 +223,7 @@ class TestNormalizeAlarmSnoozeState:
         # normalize does not touch expired snooze; filtering is done elsewhere
         assert result[1]["status"] == "SNOOZED"
         assert result[1]["snoozedToTime"] == expired_snooze
-        assert result[1]["alarmTime"] == original_alarm
+        assert result[1]["date_time"] == original_alarm
 
     # --- Non-Alarm type guard ---
 
@@ -179,7 +261,7 @@ class TestIsActiveNotification:
         assert sensor._is_active_notification(item, self.NOW) is True
 
     def test_on_alarm_is_active_even_if_in_past(self):
-        """ON alarm is active regardless of whether alarmTime is past."""
+        """ON alarm is active regardless of whether date_time is past."""
         sensor = _make_alarm_sensor()
         item = _alarm_value("ON", self.NOW - datetime.timedelta(hours=2))
         assert sensor._is_active_notification(item, self.NOW) is True

--- a/tests/test_sensor_snooze.py
+++ b/tests/test_sensor_snooze.py
@@ -69,9 +69,7 @@ class TestCoerceDatetime:
 
         result = sensor._coerce_datetime(epoch_seconds)
 
-        expected = datetime.datetime.fromtimestamp(
-            epoch_seconds, tz=self.UTC
-        )
+        expected = datetime.datetime.fromtimestamp(epoch_seconds, tz=self.UTC)
 
         assert result == expected
         assert result.tzinfo == self.UTC
@@ -84,9 +82,7 @@ class TestCoerceDatetime:
 
         result = sensor._coerce_datetime(epoch_ms)
 
-        expected = datetime.datetime.fromtimestamp(
-            epoch_ms / 1000, tz=self.UTC
-        )
+        expected = datetime.datetime.fromtimestamp(epoch_ms / 1000, tz=self.UTC)
 
         assert result == expected
         assert result.tzinfo == self.UTC
@@ -97,9 +93,7 @@ class TestCoerceDatetime:
 
         result = sensor._coerce_datetime("2024-06-01T08:00:00+00:00")
 
-        expected = datetime.datetime(
-            2024, 6, 1, 8, 0, tzinfo=self.UTC
-        )
+        expected = datetime.datetime(2024, 6, 1, 8, 0, tzinfo=self.UTC)
 
         assert result == expected
 

--- a/tests/test_sensor_snooze.py
+++ b/tests/test_sensor_snooze.py
@@ -117,11 +117,11 @@ class TestCoerceDatetime:
 
         result = sensor._coerce_datetime(naive)
 
-        expected = naive.replace(tzinfo=self.UTC)
+        expected = naive.replace(tzinfo=result.tzinfo)
 
         assert result == expected
-        assert result.tzinfo == self.UTC
-
+        assert result.utcoffset() == datetime.timedelta(0)
+        assert result.tzinfo is not None
 
 class TestNormalizeAlarmSnoozeState:
     """Unit tests for _normalize_alarm_snooze_state."""

--- a/tests/test_sensor_snooze.py
+++ b/tests/test_sensor_snooze.py
@@ -158,7 +158,7 @@ class TestIsActiveNotification:
 
     NOW = datetime.datetime(2024, 6, 1, 8, 0, 0, tzinfo=UTC)
 
-    `@staticmethod`
+    @staticmethod
     def _is_active(sensor, item, now):
         """Mirror the _is_active_notification closure from _process_raw_notifications."""
         status = item[1].get("status")

--- a/tests/test_sensor_snooze.py
+++ b/tests/test_sensor_snooze.py
@@ -71,8 +71,9 @@ class TestCoerceDatetime:
 
         expected = datetime.datetime.fromtimestamp(epoch_seconds, tz=self.UTC)
 
-        assert result == expected
-        assert result.tzinfo == self.UTC
+        assert result == expected  # equality compares instants
+        assert result.tzinfo is not None
+        assert result.utcoffset() is not None
 
     def test_epoch_milliseconds_converted_correctly(self):
         """Epoch timestamps in milliseconds should convert correctly."""
@@ -85,7 +86,7 @@ class TestCoerceDatetime:
         expected = datetime.datetime.fromtimestamp(epoch_ms / 1000, tz=self.UTC)
 
         assert result == expected
-        assert result.tzinfo == self.UTC
+        assert result.tzinfo is not None
 
     def test_iso_datetime_string_parsed_correctly(self):
         """ISO datetime strings should parse into aware datetimes."""

--- a/tests/test_sensor_snooze.py
+++ b/tests/test_sensor_snooze.py
@@ -167,6 +167,7 @@ class TestNormalizeAlarmSnoozeState:
 
 class TestIsActiveNotification:
     """Unit tests for _is_active_notification."""
+
     NOW = datetime.datetime(2024, 6, 1, 8, 0, 0, tzinfo=UTC)
 
     # --- State 1: ON ---


### PR DESCRIPTION
Add datetime coercion and alarm snooze normalization.

Fixes #3402 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of snoozed Alexa alarms: datetimes from epochs, strings, or naive values are normalized to the correct timezone; snoozed alarms are consistently labeled, ordered by the snooze timestamp, and preserved during recurring updates. Active-selection now correctly includes/excludes snoozed and expired alarms and exposes snooze timing in debug output.

* **Tests**
  * Added tests for snooze normalization, active-selection rules, datetime parsing, and boundary cases.

* **Chores**
  * Introduced a threshold constant to distinguish epoch seconds vs milliseconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->