### PR TITLE
fix: validate cookie auth before alexapy login fallback

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -805,8 +805,13 @@ async def async_setup_entry(hass, config_entry):
                         data = loads(await response.text())
                         auth = (data or {}).get("authentication") or {}
                         customer_email = (auth.get("customerEmail") or "").lower()
-                        if auth.get("authenticated") and customer_email == email.lower():
-                            _LOGGER.debug("[BOOT] Cookie auth confirmed via /api/bootstrap")
+                        if (
+                            auth.get("authenticated")
+                            and customer_email == email.lower()
+                        ):
+                            _LOGGER.debug(
+                                "[BOOT] Cookie auth confirmed via /api/bootstrap"
+                            )
                             login.status["login_successful"] = True
                             login.customer_id = auth.get("customerId")
                             login.stats["login_timestamp"] = datetime.now()

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -8,6 +8,7 @@ https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers
 """
 
 import asyncio
+import aiohttp
 from datetime import datetime, timedelta
 from json import JSONDecodeError, loads
 import logging

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -795,26 +795,26 @@ async def async_setup_entry(hass, config_entry):
             try:
                 if login._session is None or getattr(login._session, "closed", False):
                     login._create_session(True)
-                response = await login._session.get(
+                async with login._session.get(
                     "https://alexa.amazon.com/api/bootstrap",
                     cookies=cookies,
                     ssl=login._ssl,
                     allow_redirects=False,
-                )
-                if response.status == 200:
-                    data = loads(await response.text())
-                    auth = (data or {}).get("authentication") or {}
-                    customer_email = (auth.get("customerEmail") or "").lower()
-                    if auth.get("authenticated") and customer_email == email.lower():
-                        _LOGGER.debug("[BOOT] Cookie auth confirmed via /api/bootstrap")
-                        login.status["login_successful"] = True
-                        login.customer_id = auth.get("customerId")
-                        login.stats["login_timestamp"] = datetime.now()
-                        login.stats["api_calls"] = 0
-                        await login.check_domain()
-                        await login.finalize_login()
-                        cookie_login_ok = True
-            except (JSONDecodeError, ValueError) as ex:
+                ) as response:
+                    if response.status == 200:
+                        data = loads(await response.text())
+                        auth = (data or {}).get("authentication") or {}
+                        customer_email = (auth.get("customerEmail") or "").lower()
+                        if auth.get("authenticated") and customer_email == email.lower():
+                            _LOGGER.debug("[BOOT] Cookie auth confirmed via /api/bootstrap")
+                            login.status["login_successful"] = True
+                            login.customer_id = auth.get("customerId")
+                            login.stats["login_timestamp"] = datetime.now()
+                            login.stats["api_calls"] = 0
+                            await login.check_domain()
+                            await login.finalize_login()
+                            cookie_login_ok = True
+            except (JSONDecodeError, ValueError, aiohttp.ClientError) as ex:
                 _LOGGER.debug("[BOOT] Bootstrap cookie auth check failed: %s", ex)
         if not cookie_login_ok:
             await login.login(cookies=cookies)

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -8,7 +8,6 @@ https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers
 """
 
 import asyncio
-import aiohttp
 from datetime import datetime, timedelta
 from json import JSONDecodeError, loads
 import logging
@@ -17,6 +16,7 @@ import random
 import time
 from typing import Optional
 
+import aiohttp
 from alexapy import (
     AlexaAPI,
     AlexaLogin,

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -789,7 +789,35 @@ async def async_setup_entry(hass, config_entry):
     hass.bus.async_listen("alexa_media_relogin_success", login_success)
     try:
         _t = time.monotonic()
-        await login.login(cookies=await login.load_cookie())
+        cookies = await login.load_cookie()
+        cookie_login_ok = False
+        if cookies:
+            try:
+                if login._session is None or getattr(login._session, "closed", False):
+                    login._create_session(True)
+                response = await login._session.get(
+                    "https://alexa.amazon.com/api/bootstrap",
+                    cookies=cookies,
+                    ssl=login._ssl,
+                    allow_redirects=False,
+                )
+                if response.status == 200:
+                    data = loads(await response.text())
+                    auth = (data or {}).get("authentication") or {}
+                    customer_email = (auth.get("customerEmail") or "").lower()
+                    if auth.get("authenticated") and customer_email == email.lower():
+                        _LOGGER.debug("[BOOT] Cookie auth confirmed via /api/bootstrap")
+                        login.status["login_successful"] = True
+                        login.customer_id = auth.get("customerId")
+                        login.stats["login_timestamp"] = datetime.now()
+                        login.stats["api_calls"] = 0
+                        await login.check_domain()
+                        await login.finalize_login()
+                        cookie_login_ok = True
+            except (JSONDecodeError, ValueError) as ex:
+                _LOGGER.debug("[BOOT] Bootstrap cookie auth check failed: %s", ex)
+        if not cookie_login_ok:
+            await login.login(cookies=cookies)
         _LOGGER.debug("[BOOT] login completed in %.2fs", time.monotonic() - _t)
         _t = time.monotonic()
         if await test_login_status(hass, config_entry, login):


### PR DESCRIPTION
## Summary

When `alexa_media` is configured with a valid cookie pickle, validate those cookies against `https://alexa.amazon.com/api/bootstrap` before falling back to `alexapy.login()`.

This avoids a current failure mode where alexapy's login path can mutate/delete otherwise valid browser cookies before the real auth check completes, causing Home Assistant to drop into the Amazon Registration / reauth flow.

## Why

Observed on Home Assistant Core 2026.4.4 with alexa_media 5.15.1 + alexapy 1.29.20:

- The same `aiohttp.CookieJar` pickle returns HTTP 200 + `authentication.authenticated=true` from `/api/bootstrap` when tested directly.
- Calling `login.login(cookies=await login.load_cookie())` can still fail and trigger the credential/OAuth login fallback.
- During that fallback, the cookie pickle can be overwritten with a reduced/invalid jar and the integration goes to `setup_error`.

This patch performs a cheap non-redirecting bootstrap check first. If Amazon says the cookie session is authenticated for the configured email, it finalizes the login and skips the fragile fallback path. If the check fails, existing behavior is preserved.

## Test plan

- `python3 -m py_compile custom_components/alexa_media/__init__.py`
- Tested manually on a live HA installation: after applying the equivalent patch and restoring a valid pickle, `alexa_media` moved from `setup_error` to `loaded`; `notify.alexa_media_*` services came back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Alexa cookie-based sign-in: now validates stored cookies against the configured account email before completing login, correctly marks successful logins, records login identifiers, and continues normal post-login checks.
  * Enhanced error handling: if cookie validation fails or errors occur, the integration reliably falls back to the standard login flow to restore access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->