### PR TITLE
fix: restore old-style YAML groups expansion

### DIFF
--- a/custom_components/alexa_media/notify.py
+++ b/custom_components/alexa_media/notify.py
@@ -265,6 +265,10 @@ class AlexaNotificationService(BaseNotificationService):
                 expanded_targets.append(target)
         processed_targets = expanded_targets
         entities = self.convert(processed_targets, type_="entities")
+        try:
+            entities.extend(expand_entity_ids(self.hass, entities))
+        except ValueError:
+            _LOGGER.debug("Invalid Home Assistant entity in %s", entities)
         tasks = []
         for account, account_dict in self.hass.data[DATA_ALEXAMEDIA][
             "accounts"

--- a/custom_components/alexa_media/notify.py
+++ b/custom_components/alexa_media/notify.py
@@ -220,55 +220,56 @@ class AlexaNotificationService(BaseNotificationService):
                 processed_targets += json.loads(target)
                 _LOGGER.debug("Processed Target by json: %s", processed_targets)
             except json.JSONDecodeError:
-                if target.find(","):
-                    processed_targets += list(
-                        map(lambda x: x.strip(), target.split(","))
-                    )
-                    _LOGGER.debug("Processed Target by string: %s", processed_targets)
-        # Expand media_player group entities into their member entity IDs before
-        # passing to convert(). The convert() method only resolves alexa-specific
-        # identifiers (entity_id, name, serial); it has no knowledge of HA groups.
-        # We expand here — before convert() — where targets are still plain strings.
+                if "," in target:
+                    processed_targets += [
+                        item.strip() for item in target.split(",") if item.strip()
+                    ]
+                else:
+                    processed_targets.append(target.strip())
+                _LOGGER.debug("Processed Target by string: %s", processed_targets)
+        # Expand Home Assistant group targets into member entity IDs before
+        # passing to convert(). The convert() method resolves Alexa-specific
+        # identifiers (entity_id, name, serial), but it does not expand HA groups.
         #
-        # Scope: media_player groups only (identified by a media_player.* entity_id
-        # whose state contains an "entity_id" attribute listing member entities).
-        # Areas, floors, and generic group.* entities are intentionally out of scope.
+        # Supported group forms:
+        # - media_player.* helper groups with an entity_id attribute
+        # - old-style YAML group.* entities, via expand_entity_ids()
         #
-        # Note: The expand_entity_ids() call that previously appeared after convert()
-        # has been removed. It operated on already-converted alexa objects (not entity
-        # ID strings), causing it to throw ValueError on every call, which was silently
-        # swallowed — it never successfully expanded anything.
+        # Expansion happens here, while targets are still plain strings. Do not run
+        # expand_entity_ids() after convert(), because convert() returns Alexa
+        # objects, not entity ID strings.
         expanded_targets = []
+        
         for target in processed_targets:
+            if not isinstance(target, str):
+                expanded_targets.append(target)
+                continue
+        
+            # UI media_player group helper
             if (
-                isinstance(target, str)
-                and target.startswith("media_player.")
+                target.startswith("media_player.")
                 and (state := self.hass.states.get(target)) is not None
                 and "entity_id" in state.attributes
             ):
-                # This is a media_player group — expand to its member entity IDs
                 members = state.attributes["entity_id"]
-                _LOGGER.debug(
-                    "Expanding media_player group %s to members: %s", target, members
-                )
                 if isinstance(members, (list, tuple)):
                     expanded_targets.extend(members)
                 else:
-                    _LOGGER.debug(
-                        "Skipping expansion for media_player group %s: "
-                        "entity_id attribute is not a list (%s), using group as-is",
-                        target,
-                        type(members).__name__,
-                    )
                     expanded_targets.append(target)
-            else:
-                expanded_targets.append(target)
-        processed_targets = expanded_targets
-        entities = self.convert(processed_targets, type_="entities")
-        try:
-            entities.extend(expand_entity_ids(self.hass, entities))
-        except ValueError:
-            _LOGGER.debug("Invalid Home Assistant entity in %s", entities)
+                continue
+        
+            # Old-style YAML group.*, expand before convert()
+            if target.startswith("group."):
+                try:
+                    expanded_targets.extend(expand_entity_ids(self.hass, [target]))
+                except ValueError:
+                    _LOGGER.debug("Invalid Home Assistant group target: %s", target)
+                    expanded_targets.append(target)
+                continue
+        
+            expanded_targets.append(target)
+        
+        entities = self.convert(expanded_targets, type_="entities")
         tasks = []
         for account, account_dict in self.hass.data[DATA_ALEXAMEDIA][
             "accounts"

--- a/custom_components/alexa_media/notify.py
+++ b/custom_components/alexa_media/notify.py
@@ -239,12 +239,12 @@ class AlexaNotificationService(BaseNotificationService):
         # expand_entity_ids() after convert(), because convert() returns Alexa
         # objects, not entity ID strings.
         expanded_targets = []
-        
+
         for target in processed_targets:
             if not isinstance(target, str):
                 expanded_targets.append(target)
                 continue
-        
+
             # UI media_player group helper
             if (
                 target.startswith("media_player.")
@@ -257,7 +257,7 @@ class AlexaNotificationService(BaseNotificationService):
                 else:
                     expanded_targets.append(target)
                 continue
-        
+
             # Old-style YAML group.*, expand before convert()
             if target.startswith("group."):
                 try:
@@ -266,9 +266,9 @@ class AlexaNotificationService(BaseNotificationService):
                     _LOGGER.debug("Invalid Home Assistant group target: %s", target)
                     expanded_targets.append(target)
                 continue
-        
+
             expanded_targets.append(target)
-        
+
         entities = self.convert(expanded_targets, type_="entities")
         tasks = []
         for account, account_dict in self.hass.data[DATA_ALEXAMEDIA][

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -3,7 +3,7 @@
 Tests the notification service using pytest-homeassistant-custom-component.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -163,3 +163,387 @@ class TestNotifyDevicesProperty:
         assert len(result) == 2
         assert mock_player_1 in result
         assert mock_player_2 in result
+
+
+# =============================================================================
+# DRAFT: Tests for async_send_message group expansion (PR #3446)
+#
+# These tests cover the two-stage target preprocessing introduced in PR #3446:
+#   1. Normalisation: JSON / comma-delimited / bare string → list of strings
+#   2. Expansion: media_player.* helper groups and old-style group.* YAML groups
+#
+# TODO: Remove @pytest.mark.skip decorators once the test suite can import
+#       homeassistant.helpers.group cleanly in the CI environment.
+# =============================================================================
+
+
+class TestAsyncSendMessageGroupExpansion:
+    """Draft tests for target normalisation and group expansion in async_send_message.
+
+    Covers the fix introduced in PR #3446 (restore old-style YAML groups expansion):
+    - UI media_player.* helper groups are expanded via state.attributes["entity_id"]
+    - Legacy group.* YAML entities are expanded via expand_entity_ids()
+    - Targets that are not groups are passed through unchanged
+    - Non-string targets are passed through unchanged
+    - Comma-delimited and JSON string targets are normalised before expansion
+    """
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_hass(self, states: dict | None = None) -> MagicMock:
+        """Return a minimal hass mock.
+
+        Parameters
+        ----------
+        states:
+            Mapping of entity_id → dict of attributes, used to drive
+            hass.states.get().
+        """
+        hass = MagicMock()
+        hass.data = {
+            DATA_ALEXAMEDIA: {
+                "accounts": {
+                    "test@example.com": {
+                        "entities": {"media_player": {}},
+                        "options": {},
+                    }
+                }
+            }
+        }
+
+        def _states_get(entity_id):
+            if states and entity_id in states:
+                state = MagicMock()
+                state.attributes = states[entity_id]
+                return state
+            return None
+
+        hass.states.get.side_effect = _states_get
+        return hass
+
+    def _create_service(self, hass: MagicMock):
+        """Instantiate AlexaNotificationService without calling __init__."""
+        from custom_components.alexa_media.notify import AlexaNotificationService
+
+        service = object.__new__(AlexaNotificationService)
+        service.hass = hass
+        service.last_called = True
+        # Stub convert() so tests focus purely on expansion logic.
+        service.convert = MagicMock(return_value=[])
+        return service
+
+    # ------------------------------------------------------------------
+    # Target normalisation tests
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_bare_string_target_is_appended(self):
+        """A single bare string target (no comma, not JSON) is kept as-is."""
+        hass = self._make_hass()
+        service = self._create_service(hass)
+
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            return_value=["media_player.echo1"],
+        ):
+            await service.async_send_message(
+                "hello", **{"target": ["media_player.echo1"]}
+            )
+
+        service.convert.assert_called_once()
+        expanded = service.convert.call_args[0][0]
+        assert "media_player.echo1" in expanded
+
+    @pytest.mark.asyncio
+    async def test_comma_delimited_target_is_split(self):
+        """A comma-delimited target string is split into individual targets."""
+        hass = self._make_hass()
+        service = self._create_service(hass)
+
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            return_value=[],
+        ):
+            await service.async_send_message(
+                "hello",
+                **{"target": ["media_player.echo1, media_player.echo2"]},
+            )
+
+        service.convert.assert_called_once()
+        expanded = service.convert.call_args[0][0]
+        assert "media_player.echo1" in expanded
+        assert "media_player.echo2" in expanded
+
+    @pytest.mark.asyncio
+    async def test_json_string_target_is_parsed(self):
+        """A JSON-encoded list target is decoded into individual targets."""
+        import json
+
+        hass = self._make_hass()
+        service = self._create_service(hass)
+
+        json_target = json.dumps(["media_player.echo1", "media_player.echo2"])
+
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            return_value=[],
+        ):
+            await service.async_send_message(
+                "hello",
+                **{"target": [json_target]},
+            )
+
+        service.convert.assert_called_once()
+        expanded = service.convert.call_args[0][0]
+        assert "media_player.echo1" in expanded
+        assert "media_player.echo2" in expanded
+
+    # ------------------------------------------------------------------
+    # media_player.* group expansion tests
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_media_player_group_with_list_members_is_expanded(self):
+        """A media_player.* group whose entity_id attribute is a list is expanded."""
+        hass = self._make_hass(
+            states={
+                "media_player.echo_group": {
+                    "entity_id": ["media_player.echo1", "media_player.echo2"]
+                }
+            }
+        )
+        service = self._create_service(hass)
+
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            return_value=[],
+        ):
+            await service.async_send_message(
+                "hello", **{"target": ["media_player.echo_group"]}
+            )
+
+        expanded = service.convert.call_args[0][0]
+        assert "media_player.echo1" in expanded
+        assert "media_player.echo2" in expanded
+        assert "media_player.echo_group" not in expanded
+
+    @pytest.mark.asyncio
+    async def test_media_player_group_with_tuple_members_is_expanded(self):
+        """A media_player.* group whose entity_id is a tuple is expanded."""
+        hass = self._make_hass(
+            states={
+                "media_player.echo_group": {
+                    "entity_id": ("media_player.echo1", "media_player.echo2")
+                }
+            }
+        )
+        service = self._create_service(hass)
+
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            return_value=[],
+        ):
+            await service.async_send_message(
+                "hello", **{"target": ["media_player.echo_group"]}
+            )
+
+        expanded = service.convert.call_args[0][0]
+        assert "media_player.echo1" in expanded
+        assert "media_player.echo2" in expanded
+
+    @pytest.mark.asyncio
+    async def test_media_player_group_with_non_list_entity_id_kept_as_is(self):
+        """A media_player.* group whose entity_id is not a list is kept unchanged.
+
+        The code appends the group target itself rather than the scalar entity_id
+        value, matching the intent described in the PR comments.
+        """
+        hass = self._make_hass(
+            states={
+                "media_player.echo_group": {
+                    "entity_id": "media_player.echo1"  # scalar, not a list
+                }
+            }
+        )
+        service = self._create_service(hass)
+
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            return_value=[],
+        ):
+            await service.async_send_message(
+                "hello", **{"target": ["media_player.echo_group"]}
+            )
+
+        expanded = service.convert.call_args[0][0]
+        assert "media_player.echo_group" in expanded
+
+    @pytest.mark.asyncio
+    async def test_media_player_entity_without_entity_id_attr_passes_through(self):
+        """A media_player.* entity that is NOT a group (no entity_id attr) passes through."""
+        hass = self._make_hass(
+            states={
+                "media_player.echo1": {"friendly_name": "Echo"}  # no entity_id attr
+            }
+        )
+        service = self._create_service(hass)
+
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            return_value=[],
+        ):
+            await service.async_send_message(
+                "hello", **{"target": ["media_player.echo1"]}
+            )
+
+        expanded = service.convert.call_args[0][0]
+        assert "media_player.echo1" in expanded
+
+    # ------------------------------------------------------------------
+    # group.* (old-style YAML) expansion tests
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_yaml_group_is_expanded_via_expand_entity_ids(self):
+        """A group.* target is expanded using expand_entity_ids().
+
+        This is the PRIMARY regression test for PR #3446. Prior to this fix,
+        group.* targets were not handled and silently passed through without
+        expansion, so notify.alexa_media failed to reach group members.
+        """
+        hass = self._make_hass()
+        service = self._create_service(hass)
+
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            return_value=["media_player.echo1", "media_player.echo2"],
+        ) as mock_expand:
+            await service.async_send_message(
+                "hello", **{"target": ["group.echo_players"]}
+            )
+
+        mock_expand.assert_called_once_with(hass, ["group.echo_players"])
+        expanded = service.convert.call_args[0][0]
+        assert "media_player.echo1" in expanded
+        assert "media_player.echo2" in expanded
+        assert "group.echo_players" not in expanded
+
+    @pytest.mark.asyncio
+    async def test_yaml_group_expansion_falls_back_on_value_error(self):
+        """When expand_entity_ids raises ValueError the original target is kept."""
+        hass = self._make_hass()
+        service = self._create_service(hass)
+
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            side_effect=ValueError("invalid group"),
+        ):
+            await service.async_send_message(
+                "hello", **{"target": ["group.bad_group"]}
+            )
+
+        expanded = service.convert.call_args[0][0]
+        assert "group.bad_group" in expanded
+
+    @pytest.mark.asyncio
+    async def test_yaml_group_original_not_in_expanded_when_successfully_expanded(
+        self,
+    ):
+        """group.* target is removed from the list after successful expansion."""
+        hass = self._make_hass()
+        service = self._create_service(hass)
+
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            return_value=["media_player.echo1"],
+        ):
+            await service.async_send_message(
+                "hello", **{"target": ["group.echo_players"]}
+            )
+
+        expanded = service.convert.call_args[0][0]
+        assert "group.echo_players" not in expanded
+
+    # ------------------------------------------------------------------
+    # Pass-through tests
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_non_group_string_target_passes_through(self):
+        """A plain string target that is neither media_player.* nor group.* passes through."""
+        hass = self._make_hass()
+        service = self._create_service(hass)
+
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            return_value=[],
+        ):
+            await service.async_send_message(
+                "hello", **{"target": ["Living Room Echo"]}
+            )
+
+        expanded = service.convert.call_args[0][0]
+        assert "Living Room Echo" in expanded
+
+    @pytest.mark.asyncio
+    async def test_sensor_domain_target_passes_through_unchanged(self):
+        """A sensor.* target (not a group or media_player group) passes through unchanged."""
+        hass = self._make_hass()
+        service = self._create_service(hass)
+
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            return_value=[],
+        ):
+            await service.async_send_message(
+                "hello", **{"target": ["sensor.temperature"]}
+            )
+
+        expanded = service.convert.call_args[0][0]
+        assert "sensor.temperature" in expanded
+
+    # ------------------------------------------------------------------
+    # Mixed target list tests
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_mixed_group_and_plain_targets_all_resolved(self):
+        """A mix of group.*, media_player group, and plain targets is fully resolved."""
+        hass = self._make_hass(
+            states={
+                "media_player.echo_group": {
+                    "entity_id": ["media_player.echo1"]
+                }
+            }
+        )
+        service = self._create_service(hass)
+
+        def _expand(hass_arg, entity_ids):
+            if "group.echo_players" in entity_ids:
+                return ["media_player.echo2", "media_player.echo3"]
+            return entity_ids
+
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            side_effect=_expand,
+        ):
+            await service.async_send_message(
+                "hello",
+                **{
+                    "target": [
+                        "media_player.echo_group",
+                        "group.echo_players",
+                        "Living Room Echo",
+                    ]
+                },
+            )
+
+        expanded = service.convert.call_args[0][0]
+        assert "media_player.echo1" in expanded      # from media_player group
+        assert "media_player.echo2" in expanded      # from YAML group
+        assert "media_player.echo3" in expanded      # from YAML group
+        assert "Living Room Echo" in expanded        # plain target
+        assert "media_player.echo_group" not in expanded
+        assert "group.echo_players" not in expanded

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -451,9 +451,7 @@ class TestAsyncSendMessageGroupExpansion:
             "custom_components.alexa_media.notify.expand_entity_ids",
             side_effect=ValueError("invalid group"),
         ):
-            await service.async_send_message(
-                "hello", **{"target": ["group.bad_group"]}
-            )
+            await service.async_send_message("hello", **{"target": ["group.bad_group"]})
 
         service.convert.assert_called_once()
         assert service.convert.call_args.kwargs["type_"] == "entities"
@@ -531,11 +529,7 @@ class TestAsyncSendMessageGroupExpansion:
     async def test_mixed_group_and_plain_targets_all_resolved(self):
         """A mix of group.*, media_player group, and plain targets is fully resolved."""
         hass = self._make_hass(
-            states={
-                "media_player.echo_group": {
-                    "entity_id": ["media_player.echo1"]
-                }
-            }
+            states={"media_player.echo_group": {"entity_id": ["media_player.echo1"]}}
         )
         service = self._create_service(hass)
 
@@ -562,9 +556,9 @@ class TestAsyncSendMessageGroupExpansion:
         service.convert.assert_called_once()
         assert service.convert.call_args.kwargs["type_"] == "entities"
         expanded = service.convert.call_args[0][0]
-        assert "media_player.echo1" in expanded      # from media_player group
-        assert "media_player.echo2" in expanded      # from YAML group
-        assert "media_player.echo3" in expanded      # from YAML group
-        assert "Living Room Echo" in expanded        # plain target
+        assert "media_player.echo1" in expanded  # from media_player group
+        assert "media_player.echo2" in expanded  # from YAML group
+        assert "media_player.echo3" in expanded  # from YAML group
+        assert "Living Room Echo" in expanded  # plain target
         assert "media_player.echo_group" not in expanded
         assert "group.echo_players" not in expanded

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -172,8 +172,6 @@ class TestNotifyDevicesProperty:
 #   1. Normalisation: JSON / comma-delimited / bare string → list of strings
 #   2. Expansion: media_player.* helper groups and old-style group.* YAML groups
 #
-# TODO: Remove @pytest.mark.skip decorators once the test suite can import
-#       homeassistant.helpers.group cleanly in the CI environment.
 # =============================================================================
 
 
@@ -253,6 +251,7 @@ class TestAsyncSendMessageGroupExpansion:
             )
 
         service.convert.assert_called_once()
+        assert service.convert.call_args.kwargs["type_"] == "entities"
         expanded = service.convert.call_args[0][0]
         assert "media_player.echo1" in expanded
 
@@ -272,6 +271,7 @@ class TestAsyncSendMessageGroupExpansion:
             )
 
         service.convert.assert_called_once()
+        assert service.convert.call_args.kwargs["type_"] == "entities"
         expanded = service.convert.call_args[0][0]
         assert "media_player.echo1" in expanded
         assert "media_player.echo2" in expanded
@@ -296,6 +296,7 @@ class TestAsyncSendMessageGroupExpansion:
             )
 
         service.convert.assert_called_once()
+        assert service.convert.call_args.kwargs["type_"] == "entities"
         expanded = service.convert.call_args[0][0]
         assert "media_player.echo1" in expanded
         assert "media_player.echo2" in expanded
@@ -324,6 +325,8 @@ class TestAsyncSendMessageGroupExpansion:
                 "hello", **{"target": ["media_player.echo_group"]}
             )
 
+        service.convert.assert_called_once()
+        assert service.convert.call_args.kwargs["type_"] == "entities"
         expanded = service.convert.call_args[0][0]
         assert "media_player.echo1" in expanded
         assert "media_player.echo2" in expanded
@@ -349,6 +352,8 @@ class TestAsyncSendMessageGroupExpansion:
                 "hello", **{"target": ["media_player.echo_group"]}
             )
 
+        service.convert.assert_called_once()
+        assert service.convert.call_args.kwargs["type_"] == "entities"
         expanded = service.convert.call_args[0][0]
         assert "media_player.echo1" in expanded
         assert "media_player.echo2" in expanded
@@ -377,6 +382,8 @@ class TestAsyncSendMessageGroupExpansion:
                 "hello", **{"target": ["media_player.echo_group"]}
             )
 
+        service.convert.assert_called_once()
+        assert service.convert.call_args.kwargs["type_"] == "entities"
         expanded = service.convert.call_args[0][0]
         assert "media_player.echo_group" in expanded
 
@@ -398,6 +405,8 @@ class TestAsyncSendMessageGroupExpansion:
                 "hello", **{"target": ["media_player.echo1"]}
             )
 
+        service.convert.assert_called_once()
+        assert service.convert.call_args.kwargs["type_"] == "entities"
         expanded = service.convert.call_args[0][0]
         assert "media_player.echo1" in expanded
 
@@ -425,6 +434,8 @@ class TestAsyncSendMessageGroupExpansion:
             )
 
         mock_expand.assert_called_once_with(hass, ["group.echo_players"])
+        service.convert.assert_called_once()
+        assert service.convert.call_args.kwargs["type_"] == "entities"
         expanded = service.convert.call_args[0][0]
         assert "media_player.echo1" in expanded
         assert "media_player.echo2" in expanded
@@ -444,6 +455,8 @@ class TestAsyncSendMessageGroupExpansion:
                 "hello", **{"target": ["group.bad_group"]}
             )
 
+        service.convert.assert_called_once()
+        assert service.convert.call_args.kwargs["type_"] == "entities"
         expanded = service.convert.call_args[0][0]
         assert "group.bad_group" in expanded
 
@@ -463,6 +476,8 @@ class TestAsyncSendMessageGroupExpansion:
                 "hello", **{"target": ["group.echo_players"]}
             )
 
+        service.convert.assert_called_once()
+        assert service.convert.call_args.kwargs["type_"] == "entities"
         expanded = service.convert.call_args[0][0]
         assert "group.echo_players" not in expanded
 
@@ -484,6 +499,8 @@ class TestAsyncSendMessageGroupExpansion:
                 "hello", **{"target": ["Living Room Echo"]}
             )
 
+        service.convert.assert_called_once()
+        assert service.convert.call_args.kwargs["type_"] == "entities"
         expanded = service.convert.call_args[0][0]
         assert "Living Room Echo" in expanded
 
@@ -501,6 +518,8 @@ class TestAsyncSendMessageGroupExpansion:
                 "hello", **{"target": ["sensor.temperature"]}
             )
 
+        service.convert.assert_called_once()
+        assert service.convert.call_args.kwargs["type_"] == "entities"
         expanded = service.convert.call_args[0][0]
         assert "sensor.temperature" in expanded
 
@@ -540,6 +559,8 @@ class TestAsyncSendMessageGroupExpansion:
                 },
             )
 
+        service.convert.assert_called_once()
+        assert service.convert.call_args.kwargs["type_"] == "entities"
         expanded = service.convert.call_args[0][0]
         assert "media_player.echo1" in expanded      # from media_player group
         assert "media_player.echo2" in expanded      # from YAML group


### PR DESCRIPTION
Restore support for old-style YAML groups removed by PR [fix(notify): expand group entities target resolution #3437] (https://github.com/alandtse/alexa_media_player/pull/3437)

Fixes: #3444 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications now expand UI media-player helper groups and legacy group targets so messages reach all member devices.
  * Targets supplied as JSON or comma-delimited strings are normalized before processing to improve delivery accuracy.
  * Better fallback when group expansion fails to prevent delivery errors and retain original targets when expansion is invalid.

* **Tests**
  * Added async tests for target normalization, media-player and legacy group expansion, fallback behavior, and mixed-target scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->