### PR TITLE
fix: bluetooth streaming sync

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -2605,11 +2605,13 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                         if isinstance(json_payload, dict)
                         else None
                     )
+                    _LOGGER.debug("bt_event: %s", bt_event)
                     bt_success = (
                         json_payload.get("bluetoothEventSuccess")
                         if isinstance(json_payload, dict)
                         else None
                     )
+                    _LOGGER.debug("bt_success: %s", bt_success)
                     if (
                         serial
                         and serial in existing_serials
@@ -2633,6 +2635,19 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                                 f"{DOMAIN}_{hide_email(email)}"[0:32],
                                 {"bluetooth_change": bluetooth_state},
                             )
+                    elif (
+                        serial 
+                        and serial in existing_serials 
+                        and bt_event == "STREAMING_STATE_CHANGED"
+                    ):
+                        _LOGGER.debug(
+                            "Updating media_player streaming state: %s", hide_serial(json_payload)
+                        )
+                        async_dispatcher_send(
+                            hass,
+                            f"{DOMAIN}_{hide_email(email)}"[0:32],
+                            {"bluetooth_streaming_change": json_payload},
+                        )
 
                 elif command == "PUSH_MEDIA_QUEUE_CHANGE":
                     # Player availability update

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -2636,12 +2636,13 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                                 {"bluetooth_change": bluetooth_state},
                             )
                     elif (
-                        serial 
-                        and serial in existing_serials 
+                        serial
+                        and serial in existing_serials
                         and bt_event == "STREAMING_STATE_CHANGED"
                     ):
                         _LOGGER.debug(
-                            "Updating media_player streaming state: %s", hide_serial(json_payload)
+                            "Updating media_player streaming state: %s",
+                            hide_serial(json_payload),
                         )
                         async_dispatcher_send(
                             hass,

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -415,9 +415,9 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             )
         elif "bluetooth_streaming_change" in event:
             payload = event.get("bluetooth_streaming_change") or {}
-            event_serial = safe_get(payload, ["dopplerId", "deviceSerialNumber"]) or safe_get(
-                payload, ["key", "serialNumber"]
-            )
+            event_serial = safe_get(
+                payload, ["dopplerId", "deviceSerialNumber"]
+            ) or safe_get(payload, ["key", "serialNumber"])
             if event_serial is None and (
                 entry_id := safe_get(payload, ["key", "entryId"])
             ):

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -414,18 +414,22 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                 else None
             )
         elif "bluetooth_streaming_change" in event:
-            event_serial = (
-                event["bluetooth_streaming_change"]["dopplerId"]["deviceSerialNumber"]
-                if event["bluetooth_streaming_change"]
-                else None
+            payload = event.get("bluetooth_streaming_change") or {}
+            event_serial = safe_get(payload, ["dopplerId", "deviceSerialNumber"]) or safe_get(
+                payload, ["key", "serialNumber"]
             )
+            if event_serial is None and (
+                entry_id := safe_get(payload, ["key", "entryId"])
+            ):
+                parts = entry_id.split("#")
+                event_serial = parts[2] if len(parts) > 2 else None
         elif "player_state" in event:
             event_serial = (
                 event["player_state"]["dopplerId"]["deviceSerialNumber"]
                 if event["player_state"]
                 else None
             )
-            _LOGGER.debug("player_state event_serial: %s", event_serial)
+            _LOGGER.debug("player_state event_serial: %s", hide_serial(event_serial))
         elif "queue_state" in event:
             event_serial = (
                 event["queue_state"]["dopplerId"]["deviceSerialNumber"]
@@ -580,7 +584,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                         self.schedule_update_ha_state()
         elif "player_state" in event:
             player_state = event["player_state"]
-            _LOGGER.debug("player_state: %s", player_state)
+            _LOGGER.debug("player_state: %s", hide_serial(player_state))
             if event_serial == self.device_serial_number:
                 if "audioPlayerState" in player_state:
                     _LOGGER.debug(
@@ -1448,11 +1452,11 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
         ):
             return
         _LOGGER.debug(
-            "%s: %s sending PLAY command; state=%s session=%s",
+            "%s: %s sending PLAY command; state=%s media_id=%s",
             hide_email(self._login.email),
             self.name,
             self.state,
-            self._session,
+            self._session.get("mediaId") if self._session else None,
         )
         if self._playing_parent:
             await self._playing_parent.async_media_play()

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -1457,16 +1457,6 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
         if self._playing_parent:
             await self._playing_parent.async_media_play()
         else:
-            ####### Original code
-            #            if self.hass:
-            #                self.hass.async_create_task(self.alexa_api.play())
-            #            else:
-            #                await self.alexa_api.play()
-            #################################################
-
-            #            if self._session and self._session.get("mediaId") == "BluetoothMediaId":
-            #                self._player_info = None
-            #                await self.refresh(no_throttle=True)
             is_bt = self._session and self._session.get("mediaId") == "BluetoothMediaId"
             _LOGGER.debug(
                 "%s: %s PLAY precheck: is_bt=%s state=%s media_id=%s transport=%s",

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -1447,21 +1447,26 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             and self.available
         ):
             return
-        _LOGGER.debug("%s: %s sending PLAY command; state=%s session=%s",
-              hide_email(self._login.email), self.name, self.state, self._session)
+        _LOGGER.debug(
+            "%s: %s sending PLAY command; state=%s session=%s",
+            hide_email(self._login.email),
+            self.name,
+            self.state,
+            self._session,
+        )
         if self._playing_parent:
             await self._playing_parent.async_media_play()
         else:
-####### Original code
-#            if self.hass:
-#                self.hass.async_create_task(self.alexa_api.play())
-#            else:
-#                await self.alexa_api.play()
-#################################################
+            ####### Original code
+            #            if self.hass:
+            #                self.hass.async_create_task(self.alexa_api.play())
+            #            else:
+            #                await self.alexa_api.play()
+            #################################################
 
-#            if self._session and self._session.get("mediaId") == "BluetoothMediaId":
-#                self._player_info = None
-#                await self.refresh(no_throttle=True)
+            #            if self._session and self._session.get("mediaId") == "BluetoothMediaId":
+            #                self._player_info = None
+            #                await self.refresh(no_throttle=True)
             is_bt = self._session and self._session.get("mediaId") == "BluetoothMediaId"
             _LOGGER.debug(
                 "%s: %s PLAY precheck: is_bt=%s state=%s media_id=%s transport=%s",
@@ -1473,8 +1478,12 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                 self._session.get("transport") if self._session else None,
             )
             result = await self.alexa_api.play()
-            _LOGGER.debug("%s: %s PLAY result: %s",
-                hide_email(self._login.email), self.name, result)
+            _LOGGER.debug(
+                "%s: %s PLAY result: %s",
+                hide_email(self._login.email),
+                self.name,
+                result,
+            )
         if not is_http2_enabled(self.hass, self._login.email):
             await self.async_update()
 

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -578,7 +578,6 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                     )
                     if self.hass and self.schedule_update_ha_state:
                         self.schedule_update_ha_state()
-                await _refresh_if_no_audiopush(already_refreshed)
         elif "player_state" in event:
             player_state = event["player_state"]
             _LOGGER.debug("player_state: %s", player_state)

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -413,12 +413,19 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                 if event["bluetooth_change"]
                 else None
             )
+        elif "bluetooth_streaming_change" in event:
+            event_serial = (
+                event["bluetooth_streaming_change"]["dopplerId"]["deviceSerialNumber"]
+                if event["bluetooth_streaming_change"]
+                else None
+            )
         elif "player_state" in event:
             event_serial = (
                 event["player_state"]["dopplerId"]["deviceSerialNumber"]
                 if event["player_state"]
                 else None
             )
+            _LOGGER.debug("player_state event_serial: %s", event_serial)
         elif "queue_state" in event:
             event_serial = (
                 event["queue_state"]["dopplerId"]["deviceSerialNumber"]
@@ -532,6 +539,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                 )
                 self.async_schedule_update_ha_state(force_refresh=force_refresh)
         elif "bluetooth_change" in event:
+            _LOGGER.debug("bluetooth_change in event")
             if event_serial == self.device_serial_number:
                 _LOGGER.debug(
                     "%s: %s bluetooth_state update: %s",
@@ -550,8 +558,30 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                 self._bluetooth_list = self._get_bluetooth_list()
                 if self.hass and self.schedule_update_ha_state:
                     self.schedule_update_ha_state()
+        elif "bluetooth_streaming_change" in event:
+            if event_serial == self.device_serial_number:
+                if self._session and self._session.get("mediaId") == "BluetoothMediaId":
+                    current = self._session.get("state") or self._media_player_state
+
+                    if current == "PLAYING":
+                        self._media_player_state = "PAUSED"
+                        self._session["state"] = "PAUSED"
+                    elif current == "PAUSED":
+                        self._media_player_state = "PLAYING"
+                        self._session["state"] = "PLAYING"
+
+                    _LOGGER.debug(
+                        "%s: %s Bluetooth streaming state changed; optimistic state=%s",
+                        hide_email(self._login.email),
+                        self.name,
+                        self._media_player_state,
+                    )
+                    if self.hass and self.schedule_update_ha_state:
+                        self.schedule_update_ha_state()
+                await _refresh_if_no_audiopush(already_refreshed)
         elif "player_state" in event:
             player_state = event["player_state"]
+            _LOGGER.debug("player_state: %s", player_state)
             if event_serial == self.device_serial_number:
                 if "audioPlayerState" in player_state:
                     _LOGGER.debug(
@@ -625,7 +655,6 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                 await asyncio.sleep(2)
                 await self.async_update()
                 already_refreshed = True
-
         if info_changed and self._player_info and self._cluster_members:
             # This is Speaker Group or Speaker pair so throw event data
             if self.hass:
@@ -1419,13 +1448,34 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             and self.available
         ):
             return
+        _LOGGER.debug("%s: %s sending PLAY command; state=%s session=%s",
+              hide_email(self._login.email), self.name, self.state, self._session)
         if self._playing_parent:
             await self._playing_parent.async_media_play()
         else:
-            if self.hass:
-                self.hass.async_create_task(self.alexa_api.play())
-            else:
-                await self.alexa_api.play()
+####### Original code
+#            if self.hass:
+#                self.hass.async_create_task(self.alexa_api.play())
+#            else:
+#                await self.alexa_api.play()
+#################################################
+
+#            if self._session and self._session.get("mediaId") == "BluetoothMediaId":
+#                self._player_info = None
+#                await self.refresh(no_throttle=True)
+            is_bt = self._session and self._session.get("mediaId") == "BluetoothMediaId"
+            _LOGGER.debug(
+                "%s: %s PLAY precheck: is_bt=%s state=%s media_id=%s transport=%s",
+                hide_email(self._login.email),
+                self.name,
+                is_bt,
+                self.state,
+                self._session.get("mediaId") if self._session else None,
+                self._session.get("transport") if self._session else None,
+            )
+            result = await self.alexa_api.play()
+            _LOGGER.debug("%s: %s PLAY result: %s",
+                hide_email(self._login.email), self.name, result)
         if not is_http2_enabled(self.hass, self._login.email):
             await self.async_update()
 


### PR DESCRIPTION
## Fix Bluetooth playback state sync for external audio sources

### Problem

When streaming audio to an Echo device over Bluetooth (e.g. YouTube Music from a phone or laptop), Alexa Media Player receives `PUSH_BLUETOOTH_STATE_CHANGE` events with `STREAMING_STATE_CHANGED`, but these events were not handled.

As a result:

* media_player state would not update between playing/paused
* users often needed to reload the integration to refresh state
* adding a refresh on the Bluetooth push event caused subsequent `PlayCommand` requests to fail with:

  * `UnsupportedProviderException`
  * `"No routes found"`

### Solution

Handle `STREAMING_STATE_CHANGED` events separately from connect/disconnect events.

For Bluetooth media sessions (`mediaId == "BluetoothMediaId"`):

* optimistically toggle local PLAYING/PAUSED state
* update HA entity state immediately
* avoid calling `/api/np/player` from the Bluetooth streaming push handler

This preserves working Bluetooth AVRCP play/pause control while keeping the media_player entity in sync.

### Notes

Amazon's Bluetooth push payload does not include the actual playback state, only that the streaming state changed. This implementation assumes alternating PLAYING/PAUSED transitions for Bluetooth media sessions.

Normal refresh behavior during startup and scheduled polling is unchanged.

Fixes #2906 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable handling of Bluetooth streaming state changes for accurate media player status.
  * Improved detection and synchronization of Bluetooth device connection/state.

* **Improvements**
  * Faster, more responsive play/pause updates for Bluetooth playback (optimistic state updates).
  * Additional debug logging to aid troubleshooting of Bluetooth and playback issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->