### PR TITLE
fix(notify): guard targets against json.loads TypeError

### DIFF
--- a/custom_components/alexa_media/notify.py
+++ b/custom_components/alexa_media/notify.py
@@ -216,8 +216,16 @@ class AlexaNotificationService(BaseNotificationService):
         processed_targets = []
         for target in targets:
             _LOGGER.debug("Processing: %s", target)
+            if not isinstance(target, str):
+                processed_targets.append(target)
+                _LOGGER.debug("Processed non-string target: %s", processed_targets)
+                continue
             try:
-                processed_targets += json.loads(target)
+                parsed = json.loads(target)
+                if isinstance(parsed, list):
+                    processed_targets.extend(parsed)
+                else:
+                    processed_targets.append(parsed)
                 _LOGGER.debug("Processed Target by json: %s", processed_targets)
             except json.JSONDecodeError:
                 if "," in target:

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -301,6 +301,71 @@ class TestAsyncSendMessageGroupExpansion:
         assert "media_player.echo1" in expanded
         assert "media_player.echo2" in expanded
 
+    @pytest.mark.asyncio
+    async def test_non_string_dict_target_does_not_raise(self):
+        """A dict target must not raise TypeError from json.loads.
+
+        Regression test for issue #3453: ``json.loads`` only accepts
+        ``str | bytes | bytearray``. A dict (or any non-string) raised
+        ``TypeError`` outside the ``json.JSONDecodeError`` handler, aborting
+        ``async_send_message``.
+        """
+        hass = self._make_hass()
+        service = self._create_service(hass)
+
+        dict_target = {"entity_id": "media_player.echo1"}
+
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            return_value=[],
+        ):
+            await service.async_send_message("hello", **{"target": [dict_target]})
+
+        service.convert.assert_called_once()
+        expanded = service.convert.call_args[0][0]
+        assert dict_target in expanded
+
+    @pytest.mark.asyncio
+    async def test_non_string_int_target_does_not_raise(self):
+        """An int target is appended verbatim without TypeError."""
+        hass = self._make_hass()
+        service = self._create_service(hass)
+
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            return_value=[],
+        ):
+            await service.async_send_message("hello", **{"target": [42]})
+
+        service.convert.assert_called_once()
+        expanded = service.convert.call_args[0][0]
+        assert 42 in expanded
+
+    @pytest.mark.asyncio
+    async def test_json_scalar_string_target_appended_not_extended(self):
+        """JSON that decodes to a scalar (non-list) is appended, not extended.
+
+        Previous code used ``processed_targets += json.loads(target)`` which
+        would iterate a string into individual characters. The fix appends a
+        non-list parse result instead.
+        """
+        hass = self._make_hass()
+        service = self._create_service(hass)
+
+        # ``json.loads('"echo1"')`` returns the string "echo1". Under the old
+        # code, ``processed_targets += "echo1"`` would produce
+        # ``["e", "c", "h", "o", "1"]``.
+        with patch(
+            "custom_components.alexa_media.notify.expand_entity_ids",
+            return_value=[],
+        ):
+            await service.async_send_message("hello", **{"target": ['"echo1"']})
+
+        service.convert.assert_called_once()
+        expanded = service.convert.call_args[0][0]
+        assert "echo1" in expanded
+        assert "e" not in expanded
+
     # ------------------------------------------------------------------
     # media_player.* group expansion tests
     # ------------------------------------------------------------------


### PR DESCRIPTION
Fixes #3453.

`async_send_message` calls `json.loads(target)` on every entry of the
processed target list without a type guard. `json.loads` only accepts
`str | bytes | bytearray`; any non-string entry (dict, list, int) raises
`TypeError`, which is not caught by the surrounding `except
json.JSONDecodeError` block. The notify call then aborts before reaching
`convert()`.

The fix matches the snippet proposed by @alandtse in the issue:

- Skip non-string targets and append them verbatim (the existing test
  suite already documents this contract under "non-string targets are
  passed through unchanged").
- For string targets, only `.extend()` the parse result when it is a
  list; otherwise append, so a JSON scalar like `'"echo1"'` is not
  iterated into individual characters.

Three regression tests are added to `tests/test_notify.py`:

- `test_non_string_dict_target_does_not_raise`
- `test_non_string_int_target_does_not_raise`
- `test_json_scalar_string_target_appended_not_extended`

`pytest tests/test_notify.py` passes (22 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved notification service target handling to safely process various target formats, including non-string types and different JSON parsing results.
  * Enhanced robustness in message delivery to prevent type-related errors during target preprocessing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/alexa_media_player/pull/3457)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->