### PR TITLE
fix: alexa login missing host property

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -3237,7 +3237,7 @@ async def test_login_status(hass, config_entry, login) -> bool:
         title="Alexa Media Reauthentication Required",
         message=message,
         host = urlparse(login.url).hostname or login.url
-        notification_id = f"alexa_media_{slugify(login.email)}_{slugify(host)}"
+        notification_id = f"alexa_media_{slugify(login.email)}_{slugify(host)}",
     )
     flow = hass.data[DATA_ALEXAMEDIA]["config_flows"].get(
         f"{account[CONF_EMAIL]} - {account[CONF_URL]}"

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -3233,12 +3233,11 @@ async def test_login_status(hass, config_entry, login) -> bool:
         api_calls: int = login.stats.get("api_calls")
         message += f"Relogin required after {elaspsed_time} and {api_calls} api calls."
     host = urlparse(login.url).hostname or login.url
-    notification_id=f"alexa_media_{slugify(login.email)}_{slugify(host)}"
     async_create_persistent_notification(
         hass,
         title="Alexa Media Reauthentication Required",
         message=message,
-        notification_id,
+        notification_id=f"alexa_media_{slugify(login.email)}_{slugify(host)}",
     )
     flow = hass.data[DATA_ALEXAMEDIA]["config_flows"].get(
         f"{account[CONF_EMAIL]} - {account[CONF_URL]}"

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -15,6 +15,7 @@ import os
 import random
 import time
 from typing import Optional
+from urllib.parse import urlparse
 
 import aiohttp
 from alexapy import (
@@ -3235,7 +3236,8 @@ async def test_login_status(hass, config_entry, login) -> bool:
         hass,
         title="Alexa Media Reauthentication Required",
         message=message,
-        notification_id=f"alexa_media_{slugify(login.email)}{slugify(login.url[7:])}",
+        host = urlparse(login.url).hostname or login.url
+        notification_id = f"alexa_media_{slugify(login.email)}_{slugify(host)}"
     )
     flow = hass.data[DATA_ALEXAMEDIA]["config_flows"].get(
         f"{account[CONF_EMAIL]} - {account[CONF_URL]}"

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -3237,7 +3237,7 @@ async def test_login_status(hass, config_entry, login) -> bool:
         hass,
         title="Alexa Media Reauthentication Required",
         message=message,
-        notification_id = f"alexa_media_{slugify(login.email)}_{slugify(host)}",
+        notification_id=f"alexa_media_{slugify(login.email)}_{slugify(host)}",
     )
     flow = hass.data[DATA_ALEXAMEDIA]["config_flows"].get(
         f"{account[CONF_EMAIL]} - {account[CONF_URL]}"

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -3233,11 +3233,12 @@ async def test_login_status(hass, config_entry, login) -> bool:
         api_calls: int = login.stats.get("api_calls")
         message += f"Relogin required after {elaspsed_time} and {api_calls} api calls."
     host = urlparse(login.url).hostname or login.url
+    notification_id=f"alexa_media_{slugify(login.email)}_{slugify(host)}"
     async_create_persistent_notification(
         hass,
         title="Alexa Media Reauthentication Required",
         message=message,
-        notification_id=f"alexa_media_{slugify(login.email)}_{slugify(host)}",
+        notification_id,
     )
     flow = hass.data[DATA_ALEXAMEDIA]["config_flows"].get(
         f"{account[CONF_EMAIL]} - {account[CONF_URL]}"

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -3232,11 +3232,11 @@ async def test_login_status(hass, config_entry, login) -> bool:
         elaspsed_time: str = str(datetime.now() - login.stats.get("login_timestamp"))
         api_calls: int = login.stats.get("api_calls")
         message += f"Relogin required after {elaspsed_time} and {api_calls} api calls."
+    host = urlparse(login.url).hostname or login.url
     async_create_persistent_notification(
         hass,
         title="Alexa Media Reauthentication Required",
         message=message,
-        host = urlparse(login.url).hostname or login.url
         notification_id = f"alexa_media_{slugify(login.email)}_{slugify(host)}",
     )
     flow = hass.data[DATA_ALEXAMEDIA]["config_flows"].get(

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -15,6 +15,7 @@ from functools import reduce
 import html as html_lib
 import logging
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 from aiohttp import ClientConnectionError, ClientSession, InvalidURL, web, web_response
 from aiohttp.web_exceptions import HTTPBadRequest
@@ -687,7 +688,8 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                 )
                 async_dismiss_persistent_notification(
                     self.hass,
-                    notification_id=f"alexa_media_{slugify(email)}{slugify(login.url[7:])}",
+                    host = urlparse(login.url).hostname or login.url
+                    notification_id = f"alexa_media_{slugify(email)}_{slugify(host)}"
                 )
                 if not self.hass.data[DATA_ALEXAMEDIA]["accounts"].get(
                     self.config[CONF_EMAIL]
@@ -750,7 +752,8 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
             await login.close()
             async_dismiss_persistent_notification(
                 self.hass,
-                notification_id=f"alexa_media_{slugify(email)}{slugify(login.url[7:])}",
+                host = urlparse(login.url).hostname or login.url
+                notification_id = f"alexa_media_{slugify(email)}_{slugify(host)}"
             )
             return self.async_abort(reason="login_failed")
         new_schema = self._update_schema_defaults()

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -689,7 +689,7 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                 host = urlparse(login.url).hostname or login.url
                 async_dismiss_persistent_notification(
                     self.hass,
-                    notification_id = f"alexa_media_{slugify(email)}_{slugify(host)}"
+                    notification_id=f"alexa_media_{slugify(email)}_{slugify(host)}",
                 )
                 if not self.hass.data[DATA_ALEXAMEDIA]["accounts"].get(
                     self.config[CONF_EMAIL]
@@ -753,7 +753,7 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
             await login.close()
             async_dismiss_persistent_notification(
                 self.hass,
-                notification_id = f"alexa_media_{slugify(email)}_{slugify(host)}"
+                notification_id=f"alexa_media_{slugify(email)}_{slugify(host)}",
             )
             return self.async_abort(reason="login_failed")
         new_schema = self._update_schema_defaults()

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -687,9 +687,10 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                     event_data={"email": hide_email(email), "url": login.url},
                 )
                 host = urlparse(login.url).hostname or login.url
+                notification_id=f"alexa_media_{slugify(email)}_{slugify(host)}"
                 async_dismiss_persistent_notification(
                     self.hass,
-                    notification_id=f"alexa_media_{slugify(email)}_{slugify(host)}",
+                    notification_id,
                 )
                 if not self.hass.data[DATA_ALEXAMEDIA]["accounts"].get(
                     self.config[CONF_EMAIL]

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -687,7 +687,7 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                     event_data={"email": hide_email(email), "url": login.url},
                 )
                 host = urlparse(login.url).hostname or login.url
-                notification_id=f"alexa_media_{slugify(email)}_{slugify(host)}"
+                notification_id = f"alexa_media_{slugify(email)}_{slugify(host)}"
                 async_dismiss_persistent_notification(
                     self.hass,
                     notification_id,

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -751,7 +751,7 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
         if login.status and (login.status.get("login_failed")):
             _LOGGER.debug("Login failed: %s", login.status.get("login_failed"))
             host = urlparse(login.url).hostname or login.url
-            notification_id=f"alexa_media_{slugify(email)}_{slugify(host)}"
+            notification_id = f"alexa_media_{slugify(email)}_{slugify(host)}"
             await login.close()
             async_dismiss_persistent_notification(
                 self.hass,

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -686,9 +686,9 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                     "alexa_media_relogin_success",
                     event_data={"email": hide_email(email), "url": login.url},
                 )
+                host = urlparse(login.url).hostname or login.url
                 async_dismiss_persistent_notification(
                     self.hass,
-                    host = urlparse(login.url).hostname or login.url
                     notification_id = f"alexa_media_{slugify(email)}_{slugify(host)}"
                 )
                 if not self.hass.data[DATA_ALEXAMEDIA]["accounts"].get(
@@ -749,10 +749,10 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                 )
         if login.status and (login.status.get("login_failed")):
             _LOGGER.debug("Login failed: %s", login.status.get("login_failed"))
+            host = urlparse(login.url).hostname or login.url
             await login.close()
             async_dismiss_persistent_notification(
                 self.hass,
-                host = urlparse(login.url).hostname or login.url
                 notification_id = f"alexa_media_{slugify(email)}_{slugify(host)}"
             )
             return self.async_abort(reason="login_failed")

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -751,10 +751,11 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
         if login.status and (login.status.get("login_failed")):
             _LOGGER.debug("Login failed: %s", login.status.get("login_failed"))
             host = urlparse(login.url).hostname or login.url
+            notification_id=f"alexa_media_{slugify(email)}_{slugify(host)}"
             await login.close()
             async_dismiss_persistent_notification(
                 self.hass,
-                notification_id=f"alexa_media_{slugify(email)}_{slugify(host)}",
+                notification_id,
             )
             return self.async_abort(reason="login_failed")
         new_schema = self._update_schema_defaults()


### PR DESCRIPTION
#### Problem

In `custom_components/alexa_media/__init__.py`, the host is extracted via:

```python
notification_id=f"alexa_media_{slugify(login.email)}{slugify(login.url[7:])}",
```

`login.url[7:]` silently breaks if the URL scheme is not exactly 7 characters (e.g. `https://` is 8 chars, not 7), making this a correctness bug.

#### Solution

**`custom_components/alexa_media/config_flow.py`** (lines 690 and 753):
```python
from urllib.parse import urlparse

host = urlparse(login.url).hostname or login.url
notification_id = f"alexa_media_{slugify(email)}_{slugify(host)}"
```

**`custom_components/alexa_media/__init__.py`** (line 3238):
```python
from urllib.parse import urlparse

host = urlparse(login.url).hostname or login.url
notification_id = f"alexa_media_{slugify(login.email)}_{slugify(host)}"
```

Fixes #3460 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Persistent reauthentication notifications are now uniquely tied to each Alexa account and host, so reauth warnings are correctly identified and dismissed per host. This also handles cases where a host cannot be determined, preventing duplicate or lingering reauthentication notices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/alexa_media_player/pull/3461)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->