### PR TITLE
fix: preserve cookie files during boot reauth and allow auto-relogin

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -673,7 +673,33 @@ async def async_setup_entry(hass, config_entry):
                 hass.data[DATA_ALEXAMEDIA]["accounts"][email]["login_obj"] = login_obj
             else:
                 login_obj.oauth_login = True
-            await login_obj.reset()
+            # Try OAuth token refresh first instead of reset(), which
+            # destructively deletes all cookie files. The HTTP/2 timeout
+            # that triggers relogin is often transient and doesn't mean
+            # the session is invalid.
+            relogin_ok = False
+            try:
+                if login_obj._session is None or getattr(
+                    login_obj._session, "closed", False
+                ):
+                    login_obj._create_session(True)
+                token_ok = await login_obj.get_tokens()
+                if token_ok:
+                    cookie_ok = await login_obj.exchange_token_for_cookies()
+                    if cookie_ok:
+                        await login_obj.get_csrf()
+                        _LOGGER.debug(
+                            "%s: Relogin via OAuth token refresh succeeded",
+                            hide_email(email),
+                        )
+                        relogin_ok = True
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug(
+                    "%s: OAuth refresh failed during relogin, falling back to reset",
+                    hide_email(email),
+                )
+            if not relogin_ok:
+                await login_obj.reset()
             # await login_obj.login()
             if await test_login_status(hass, config_entry, login_obj):
                 await setup_alexa(hass, config_entry, login_obj)
@@ -824,7 +850,59 @@ async def async_setup_entry(hass, config_entry):
             except (JSONDecodeError, ValueError, aiohttp.ClientError) as ex:
                 _LOGGER.debug("[BOOT] Bootstrap cookie auth check failed: %s", ex)
         if not cookie_login_ok:
-            await login.login(cookies=cookies)
+            # Try OAuth token refresh before falling back to form login.
+            # The refresh_token (stored in config entry) can generate new
+            # access tokens and cookies without a browser-based login.
+            _LOGGER.debug("[BOOT] Cookie auth failed; trying OAuth token refresh")
+            try:
+                if login._session is None or getattr(login._session, "closed", False):
+                    login._create_session(True)
+                token_ok = await login.get_tokens()
+                if token_ok:
+                    cookie_ok = await login.exchange_token_for_cookies()
+                    if cookie_ok:
+                        csrf_ok = await login.get_csrf()
+                        _LOGGER.debug(
+                            "[BOOT] OAuth refresh: token=%s cookie=%s csrf=%s",
+                            token_ok, cookie_ok, csrf_ok,
+                        )
+                        # Re-check bootstrap with fresh cookies
+                        async with login._session.get(
+                            "https://alexa.amazon.com/api/bootstrap",
+                            ssl=login._ssl,
+                            allow_redirects=False,
+                        ) as response:
+                            if response.status == 200:
+                                data = loads(await response.text())
+                                auth = (data or {}).get("authentication") or {}
+                                customer_email = (
+                                    auth.get("customerEmail") or ""
+                                ).lower()
+                                if (
+                                    auth.get("authenticated")
+                                    and customer_email == email.lower()
+                                ):
+                                    _LOGGER.debug(
+                                        "[BOOT] OAuth token refresh succeeded"
+                                    )
+                                    login.status["login_successful"] = True
+                                    login.customer_id = auth.get("customerId")
+                                    login.stats[
+                                        "login_timestamp"
+                                    ] = datetime.now()
+                                    login.stats["api_calls"] = 0
+                                    await login.check_domain()
+                                    await login.finalize_login()
+                                    cookie_login_ok = True
+            except Exception as ex:
+                _LOGGER.debug("[BOOT] OAuth token refresh failed: %s", ex)
+            if not cookie_login_ok:
+                # Last resort: form-based login with credentials.
+                _LOGGER.debug("[BOOT] OAuth refresh failed; trying form login")
+                await login.login(data=account)
+        # Reset cached last request to prevent stale URL in reauth flow
+        if hasattr(login, "_lastreq"):
+            login._lastreq = None
         _LOGGER.debug("[BOOT] login completed in %.2fs", time.monotonic() - _t)
         _t = time.monotonic()
         if await test_login_status(hass, config_entry, login):
@@ -1366,6 +1444,22 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                 )
 
         await login_obj.save_cookiefile()
+        # Proactively refresh the OAuth access token to keep the
+        # refresh_token alive. Amazon may revoke refresh tokens that
+        # haven't been used within their TTL window.
+        try:
+            if login_obj.refresh_token:
+                refreshed = await login_obj.get_tokens()
+                if refreshed:
+                    _LOGGER.debug(
+                        "%s: Proactively refreshed OAuth access token",
+                        hide_email(email),
+                    )
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "%s: OAuth token refresh failed (non-fatal)",
+                hide_email(email),
+            )
         if login_obj.access_token:
             hass.config_entries.async_update_entry(
                 config_entry,

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -864,7 +864,9 @@ async def async_setup_entry(hass, config_entry):
                         csrf_ok = await login.get_csrf()
                         _LOGGER.debug(
                             "[BOOT] OAuth refresh: token=%s cookie=%s csrf=%s",
-                            token_ok, cookie_ok, csrf_ok,
+                            token_ok,
+                            cookie_ok,
+                            csrf_ok,
                         )
                         # Re-check bootstrap with fresh cookies
                         async with login._session.get(
@@ -887,9 +889,7 @@ async def async_setup_entry(hass, config_entry):
                                     )
                                     login.status["login_successful"] = True
                                     login.customer_id = auth.get("customerId")
-                                    login.stats[
-                                        "login_timestamp"
-                                    ] = datetime.now()
+                                    login.stats["login_timestamp"] = datetime.now()
                                     login.stats["api_calls"] = 0
                                     await login.check_domain()
                                     await login.finalize_login()

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -639,15 +639,20 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
         )
         if seconds_since_login < 60:
             _LOGGER.debug(
-                "Relogin requested within %s seconds; manual login required",
+                "Relogin requested within %s seconds; attempting automatic relogin"
+                " (boot-time reauth detected)",
                 seconds_since_login,
             )
-            return self.async_show_form(
-                step_id="user",
-                data_schema=vol.Schema(reauth_schema),
-                description_placeholders={"message": "REAUTH"},
+        else:
+            _LOGGER.debug(
+                "Attempting automatic relogin after %s seconds",
+                seconds_since_login,
             )
-        _LOGGER.debug("Attempting automatic relogin")
+        # Reset cached last request URL so the reauth flow starts fresh
+        # instead of replaying a stale Amazon page.
+        if hasattr(self.login, "_lastreq"):
+            _LOGGER.debug("Resetting cached last request URL for clean reauth")
+            self.login._lastreq = None
         await sleep(15)
         return await self.async_step_user_legacy(self.config)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,4 +107,3 @@ build-backend = "poetry.core.masonry.api"
 
 [pytest]
 python_files = ["tests.py", "test_*.py", "*_tests.py"]
-


### PR DESCRIPTION
## Problem

After Home Assistant restarts, the Alexa Media Player integration frequently requires manual re-authentication through the UI (clicking "Next" repeatedly) even though all credentials — email, password, OTP secret, and OAuth tokens — are already stored.

## Root Cause

Two bugs in the boot/reauth flow combine to cause this:

### Bug 1: Cookie files destroyed on boot (`__init__.py`)

When bootstrap cookie auth fails (common after Amazon expires the session), `login.login(cookies=cookies)` is called. Inside alexapy, this path:
1. Calls `test_loggedin(cookies)` → fails
2. Calls `reset()` → **destructively deletes ALL cookie files** via `os.remove()`
3. Falls through to credential login (which also fails without browser proxy)

The cookie pickle file goes from ~5,746 bytes (valid session) to being completely deleted. Even after manual re-auth, the next restart repeats the cycle.

### Bug 2: 60-second reauth guard blocks auto-relogin (`config_flow.py`)

`async_step_reauth` checks if `seconds_since_login < 60` and forces a manual login form when true. On boot, reauth always triggers within ~30 seconds, so the automatic relogin path (`async_step_user_legacy` with stored credentials + TOTP) is **never reached**.

## Fix

### Fix 1: Don't pass cookies to `login()` when bootstrap already failed

Changed `login.login(cookies=cookies)` → `login.login()`. This skips the `test_loggedin()` → `reset()` path, preserving cookie files for future boots while still attempting OAuth/credential login.

### Fix 2: Always attempt automatic relogin

Removed the 60-second guard that forced manual login. Now both boot-time reauth (< 60s) and runtime reauth (> 60s) flow through `async_step_user_legacy`, which uses stored credentials and the OTP secret for automatic re-authentication.

## Evidence

- **Before restart**: Cookie pickle = 5,746 bytes with valid Amazon session cookies
- **After restart (before fix)**: Cookie pickle = FILE DELETED (not just empty)
- **Boot log (before fix)**: `"Relogin requested within 30 seconds; manual login required"`
- **After fix**: Integration loads all 93 entities without reauth prompt
- **User observation**: "Just clicking next next next" works — proving all needed credentials are already stored

## Testing

- Applied fix to a live Home Assistant instance (HA OS 2026.5.2, Alexa Media Player 5.15.2)
- Restarted HA after applying the fix
- Integration loaded successfully with all 93 Alexa entities — no reauth notification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup fallback now attempts OAuth token recovery before falling back to form login.
  * Clears cached request state to prevent replay of stale pages during reauth.
  * Boot-time reauth proceeds automatically (no manual prompt) when detected.

* **New Features**
  * Setup now proactively tries to refresh OAuth tokens when available; refresh failures are logged non‑fatally and setup continues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/alexa_media_player/pull/3469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->