### PR TITLE
fix: http2_close_handler

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -2867,6 +2867,7 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                 "%s: HTTP2Push connection closed; retries exceeded; polling",
                 hide_email(email),
             )
+        coordinator = hass.data[DATA_ALEXAMEDIA]["accounts"][email].get("coordinator")
         if coordinator:
             coordinator.update_interval = timedelta(
                 seconds=scan_interval * 10 if http2_enabled else scan_interval


### PR DESCRIPTION
#### Problem
http2_close_handler() closes over coordinator, but coordinator is assigned later, after await http2_connect(). If HTTP2 closes during/around that first connect, the closure cell exists but has no value yet, causing this NameError.

#### Fix
Do a live lookup inside http2_close_handler instead of relying on the outer coordinator variable.

#### Fixes
#3473 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where polling could fail in certain connection scenarios, ensuring reliable data updates when alternative connection methods are in use.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/alexa_media_player/pull/3474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->